### PR TITLE
Allow handling http errors

### DIFF
--- a/lib/feedparser.js
+++ b/lib/feedparser.js
@@ -547,7 +547,9 @@ FeedParser.prototype.parseFile = function(file, callback) {
 FeedParser.prototype.parseUrl = function(url, callback) {
   var self = this;
   self._reset(callback);
-  request(url).pipe(self.saxStream);
+  var httpRequest = request(url);
+  httpRequest.on('error', function (e){ self.handleError(e, self); });
+  httpRequest.pipe(self.saxStream);
 };
 
 /**
@@ -597,8 +599,10 @@ FeedParser.prototype.handleError = function (e, scope){
   var self = scope;
   self.emit('error', e);
   self.errors.push(e);
-  self._parser.error = null;
-  self._parser.resume();
+  if (self._parser) {
+    self._parser.error = null;
+    self._parser.resume();
+  }
 };
 
 FeedParser.prototype.handleOpenTag = function (node, scope){


### PR DESCRIPTION
Try parseUrl('http://some-invalid-domain.com/') and app crashes with Error: getaddrinfo ENOENT, so let's bind an error handler to request() and pass http-level errors along.
