### PR TITLE
global item variable fix

### DIFF
--- a/lib/feedparser.js
+++ b/lib/feedparser.js
@@ -735,7 +735,7 @@ FeedParser.prototype.handleCloseTag = function (el, scope){
       Object.merge(self.meta, handleMeta(self.stack[0], self.meta['#type']), true);
       self.emit('meta', self.meta);
     }
-    item = handleItem(n, self.meta['#type']);
+    var item = handleItem(n, self.meta['#type']);
     item.meta = self.meta;
     if (self.meta.author && !item.author) item.author = self.meta.author;
     self.emit('article', item);


### PR DESCRIPTION
Hi Dan,

I'm using your feed parser in my project (thanks for such a nice utility) and I noticed my Mocha tests complain about feedparser leaking item variable into the global namespace. So I took the liberty of fixing it (I didn't spend too much time on it, but it looks like that variable does not need to be global - correct me if I'm wrong).

All the best
Tomas
