### PR TITLE
Fixed uncaught error when parsing certain URLs

### DIFF
--- a/main.js
+++ b/main.js
@@ -1140,7 +1140,11 @@ FeedParser.parseUrl = function (url, options, callback) {
   var handleResponse = function (response) {
     fp.emit('response', response);
     var code = response.statusCode;
-    var codeReason = response.request.httpModule.STATUS_CODES[code] || 'Unknown Failure';
+    if (response.request.httpModule.STATUS_CODES != undefined) {
+      var codeReason = response.request.httpModule.STATUS_CODES[code] || 'Unknown Failure';
+    } else {
+      var codeReason = "Unknown Failure"
+    }
     var contentType = response.headers && response.headers['content-type'];
     var e = new Error();
     if (code !== 200) {


### PR DESCRIPTION
Found an issue when parsing certain URLs.

The problem first presented itself when parsing `https://api.twitter.com/1/statuses/user_timeline.rss?screen_name=patrickod`. It would fail with an uncaught error in main.js around line 1143 trying to get a status code for the returned response.

Now it checks that the STATUS_CODES object exists before trying to use it.
