### PR TITLE
make example work with new api

### DIFF
--- a/examples/simple.js
+++ b/examples/simple.js
@@ -4,13 +4,9 @@
  * MIT Licensed
  */
 
-var FeedParser = require('../lib/feedparser')
-  , parser
-
-parser = new FeedParser();
+var feedparser = require(__dirname+'/..'),
+    parser = feedparser.parseUrl('http://cyber.law.harvard.edu/rss/examples/rss2sample.xml');
 
 parser.on('article', function(article){
     console.log('Got article: %s', JSON.stringify(article));
 });
-
-parser.parseFile('http://cyber.law.harvard.edu/rss/examples/rss2sample.xml');


### PR DESCRIPTION
The example was using deprecated methods.
