### PR TITLE
Fix for no Content-Type header

### DIFF
--- a/main.js
+++ b/main.js
@@ -1107,7 +1107,7 @@ FeedParser.parseUrl = function (url, options, callback) {
     fp.emit('response', response);
     var code = response.statusCode;
     var codeReason = STATUS_CODES[code] || 'Unknown Failure';
-    var contentType = response.headers && response.headers['content-type'];
+    var contentType = response.headers && response.headers['content-type'] || '';
     var e = new Error();
     if (code !== 200) {
       if (code === 304) {


### PR DESCRIPTION
0.15 throws an error when loading feeds that are returned without a Content-Type header.  This patch fixes that by assuming an empty string instead of `undefined`.
