### PR TITLE
do not seperate rss catgories by comma

### DIFF
--- a/main.js
+++ b/main.js
@@ -570,8 +570,7 @@ FeedParser.prototype.handleMeta = function handleMeta (node, type, options) {
             if ('category' == name && 'atom' == type) {
               if (category['@'] && utils.get(category['@'], 'term')) meta.categories.push(utils.get(category['@'], 'term'));
             } else if ('category' == name && utils.get(category) && 'rss' == type) {
-              _categories = utils.get(category).split(',').map(function (cat){ return cat.trim(); });
-              if (_categories.length) meta.categories = meta.categories.concat(_categories);
+              meta.categories.push(utils.get(category).trim());
             } else if ('dc:subject' == name && utils.get(category)) {
               _categories = utils.get(category).split(' ').map(function (cat){ return cat.trim(); });
               if (_categories.length) meta.categories = meta.categories.concat(_categories);
@@ -597,8 +596,7 @@ FeedParser.prototype.handleMeta = function handleMeta (node, type, options) {
           if ('category' == name && 'atom' == type) {
             if (utils.get(el['@'], 'term')) meta.categories.push(utils.get(el['@'], 'term'));
           } else if ('category' == name && utils.get(el) && 'rss' == type) {
-            _categories = utils.get(el).split(',').map(function (cat){ return cat.trim(); });
-            if (_categories.length) meta.categories = meta.categories.concat(_categories);
+            meta.categories.push(utils.get(el).trim());
           } else if ('dc:subject' == name && utils.get(el)) {
             _categories = utils.get(el).split(' ').map(function (cat){ return cat.trim(); });
             if (_categories.length) meta.categories = meta.categories.concat(_categories);
@@ -875,8 +873,7 @@ FeedParser.prototype.handleItem = function handleItem (node, type, options){
             if ('category' == name && 'atom' == type) {
               if (category['@'] && utils.get(category['@'], 'term')) item.categories.push(utils.get(category['@'], 'term'));
             } else if ('category' == name && utils.get(category) && 'rss' == type) {
-              _categories = utils.get(category).split(',').map(function (cat){ return cat.trim(); });
-              if (_categories.length) item.categories = item.categories.concat(_categories);
+              item.categories.push(utils.get(category).trim());
             } else if ('dc:subject' == name && utils.get(category)) {
               _categories = utils.get(category).split(' ').map(function (cat){ return cat.trim(); });
               if (_categories.length) item.categories = item.categories.concat(_categories);
@@ -902,8 +899,7 @@ FeedParser.prototype.handleItem = function handleItem (node, type, options){
           if ('category' == name && 'atom' == type) {
             if (utils.get(el['@'], 'term')) item.categories.push(utils.get(el['@'], 'term'));
           } else if ('category' == name && utils.get(el) && 'rss' == type) {
-            _categories = utils.get(el).split(',').map(function (cat){ return cat.trim(); });
-            if (_categories.length) item.categories = item.categories.concat(_categories);
+            item.categories.push(utils.get(el).trim());
           } else if ('dc:subject' == name && utils.get(el)) {
             _categories = utils.get(el).split(' ').map(function (cat){ return cat.trim(); });
             if (_categories.length) item.categories = item.categories.concat(_categories);

--- a/test/category.js
+++ b/test/category.js
@@ -1,0 +1,26 @@
+describe('feedparser', function(){
+
+  var feed = __dirname + '/feeds/category-feed.xml'
+    , meta = {}
+    , articles = {}
+    ;
+
+  describe('categories with comma in them', function(){
+    before(function(done){
+      FeedParser.parseFile(feed, function (error, _meta, _articles) {
+        assert.ifError(error);
+        meta = _meta;
+        articles = _articles;
+        done();
+      });
+    });
+    describe('article', function(){
+      it('should should not seperate by comma', function() {
+        assert.deepEqual(articles[0].categories, [
+          'Water Pollution',
+          'Gowanus Canal (Brooklyn, NY)'
+        ]);
+      });
+    });
+  });
+});

--- a/test/feeds/category-feed.xml
+++ b/test/feeds/category-feed.xml
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?xml-stylesheet type='text/xsl' href='http://rss.nytimes.com/xsl/eng/rss.xsl'?>
+<rss xmlns:itunes="http://www.itunes.com/dtds/podcast-1.0.dtd" xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:taxo="http://purl.org/rss/1.0/modules/taxonomy/" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:atom="http://www.w3.org/2005/Atom" xmlns:media="http://search.yahoo.com/mrss/" version="2.0">
+<channel>
+    <atom:link href="http://www.nytimes.com/services/xml/rss/nyt/HomePage.xml" rel="self" type="application/rss+xml"/>
+    <title>NYT &gt; Home Page</title>
+    <link>http://www.nytimes.com/pages/index.html?partner=rss&amp;emc=rss</link>
+    <description>HomePage</description>
+    <language>en-us</language>
+    <copyright>Copyright 2013 The New York Times Company</copyright>
+    <pubDate>Sun, 05 May 2013 17:21:47 GMT</pubDate>
+    <lastBuildDate>Sun, 05 May 2013 17:21:47 GMT</lastBuildDate>
+    <item>
+        <atom:link href="http://www.nytimes.com/2013/05/06/nyregion/epa-plan-to-clean-up-gowanus-canal-meets-local-resistance.html?partner=rss&amp;emc=rss" rel="standout"/>
+        <title>E.P.A. Plan to Clean Up Gowanus Canal Meets Local Resistance</title>
+        <link>http://www.nytimes.com/2013/05/06/nyregion/epa-plan-to-clean-up-gowanus-canal-meets-local-resistance.html?partner=rss&amp;emc=rss</link>
+        <description>Removed for overview ...</description>
+        <category domain="http://www.nytimes.com/namespaces/keywords/des">Water Pollution</category>
+        <category domain="http://www.nytimes.com/namespaces/keywords/nyt_geo">Gowanus Canal (Brooklyn, NY)</category>
+        <pubDate>Sun, 05 May 2013 17:15:11 GMT</pubDate>
+    </item>
+</channel>
+</rss>


### PR DESCRIPTION
I can't find any documentation supporting that RSS categories should be separated by a comma.
