### PR TITLE
make feedparser a transform stream

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,8 @@ as I'm sure the stream API is stable and compatible with Node v0.10.x.
 
 ## Usage
 
-The easiest way to use feedparser is to just give it a [readable stream](http://nodejs.org/api/stream.html#stream_readable_stream).
+The easiest way to use feedparser is to just give it a [readable stream](http://nodejs.org/api/stream.html#stream_readable_stream). 
+It will then return a readable object stream containing `article` objects.
 
 ```js
 
@@ -47,7 +48,7 @@ request('http://somefeedurl.xml')
   .on('meta', function (meta) {
     // do something
   })
-  .on('article', function (article) {
+  .on('data', function (article) {
     // do something else
   })
   .on('end', function () {
@@ -108,7 +109,7 @@ See the `examples` directory.
 
 * `error` - called with `error` whenever there is a an error of any kind (SAXError, Feedparser error, request error, etc.)
 * `meta` - called with `meta` when it has been parsed
-* `article` - called with a single `article` when each article has been parsed
+* `data` and `article` - called with a single `article` when each article has been parsed
 * `complete` - called with `meta` and `articles` when parsing is complete
 * `end` - called with no parameters when parsing is complete or aborted (e.g., due to error)
 * `response` - called with the HTTP `response` only when a url has been fetched via parseUrl or parseFile

--- a/package.json
+++ b/package.json
@@ -30,11 +30,13 @@
     "request": "2.9.x",
     "addressparser": "~0.1.3",
     "array-indexofobject": "0.0.1",
+    "readable-stream": "1.0.x",
     "resanitize": "~0.1.10"
   },
   "devDependencies": {
     "mocha": "1.x",
-    "buffet": "0.4.x"
+    "buffet": "0.4.x",
+    "endpoint": "0.4.x"
   },
   "scripts": {
     "test": "./node_modules/mocha/bin/mocha"

--- a/test/api-event.js
+++ b/test/api-event.js
@@ -47,9 +47,8 @@ describe('Event API', function () {
             assert.ok(articles.length);
             events.push('complete');
           })
-          .on('end', function () {
-            done();
-          });
+          .on('end', done)
+          .resume();
       });
     });
 
@@ -73,7 +72,8 @@ describe('Event API', function () {
             assert.ok(articles.length);
             events.push('complete');
           })
-          .on('end', done);
+          .on('end', done)
+          .resume();
       });
     });
 
@@ -97,8 +97,8 @@ describe('Event API', function () {
             assert.ok(articles.length);
             events.push('complete');
           })
-          .on('end', done);
-
+          .on('end', done)
+          .resume();
       });
     });
 
@@ -110,7 +110,8 @@ describe('Event API', function () {
         .on('error', function (err) {
           assert.ok(err instanceof Error);
         })
-        .on('end', done);
+        .on('end', done)
+        .resume();
     });
   });
 });

--- a/test/api-stream.js
+++ b/test/api-stream.js
@@ -1,23 +1,15 @@
+var fs = require('fs');
+var endpoint = require('endpoint');
+
 describe('Writeable Stream Input API', function () {
 
   var feedPath = __dirname + '/feeds/rss2sample.xml';
 
-  var events = [];
-
-  beforeEach(function () {
-    events = [];
-  })
-
-  afterEach(function () {
-    assert.equal(events.indexOf('error'), -1);
-    assert.ok(~events.indexOf('meta'));
-    assert.ok(~events.indexOf('article'));
-    assert.ok(~events.indexOf('complete'));
-  });
-
   describe('.pipe()', function () {
     it('works', function (done) {
-      require('fs').createReadStream(feedPath).pipe(FeedParser())
+      var events = [];
+
+      fs.createReadStream(feedPath).pipe(FeedParser())
         .on('error', function (err) {
           assert.ifError(err);
           events.push('error');
@@ -35,7 +27,26 @@ describe('Writeable Stream Input API', function () {
           assert.ok(articles.length);
           events.push('complete');
         })
-        .on('end', done);
+        .on('end', function () {
+          assert.equal(events.indexOf('error'), -1);
+          assert.ok(~events.indexOf('meta'));
+          assert.ok(~events.indexOf('article'));
+          assert.ok(~events.indexOf('complete'));
+          done();
+        })
+        .resume();
+    });
+  });
+
+  describe('.pipe()', function () {
+    it('works', function (done) {
+      fs.createReadStream(feedPath)
+        .pipe(FeedParser())
+        .pipe(endpoint({objectMode: true}, function (err, articles) {
+          assert.equal(err, null);
+          assert.ok(articles.length);
+          done();
+        }));
     });
   });
 


### PR DESCRIPTION
You are so very close to have a real transform stream, this takes the last step and uses the node 0.10, transform class.

I have tried hard to maintain backwards compatibility, only if the user listens to `end` there can be a difference. But I really think you should drop all those callbacks and extra methods (`parseUrl`, `parseString`, `parseFile`) and make this a pure transform stream. Users can then use stream/buffer tools like `createReadStream`, `request`, `endpoint` and `startpoint` to get the similar results.

_Note that your tests on master (and this branch too) seams to be unstable!_
