### PR TITLE
improve stream buffering

### DIFF
--- a/main.js
+++ b/main.js
@@ -98,6 +98,7 @@ FeedParser.prototype.init = function (){
   };
   this._emitted_meta = false;
   this.stack = [];
+  this.nodes = {};
   this.xmlbase = [];
   this.in_xhtml = false;
   this.xhtml = {}; /* Where to store xhtml elements as associative
@@ -335,6 +336,8 @@ FeedParser.prototype.handleCloseTag = function (el){
     } else {
       this.stack[0][stdEl] = [this.stack[0][stdEl], n];
     }
+  } else {
+    this.nodes = n;
   }
 };
 


### PR DESCRIPTION
This PR helps with https://github.com/danmactough/node-feedparser/issues/80
It also configures in a better way the watermark for FeedParser, as both sides of the feed should not be in objectMode.
All tests still pass.
