### PR TITLE
Feature: meta selectably emits once per write

### DIFF
--- a/main.js
+++ b/main.js
@@ -110,6 +110,7 @@ FeedParser.prototype.parseOpts = function (options) {
   if (!('normalize' in this.options)) this.options.normalize = true;
   if (!('addmeta' in this.options)) this.options.addmeta = true;
   if (!('resume_saxerror' in this.options)) this.options.resume_saxerror = true;
+  if (!('emit_meta_once' in this.options)) this.options.emit_meta_once = true;
   if ('MAX_BUFFER_LENGTH' in this.options) {
     sax.MAX_BUFFER_LENGTH = this.options.MAX_BUFFER_LENGTH; // set to Infinity to have unlimited buffers
   } else {
@@ -1020,6 +1021,10 @@ FeedParser.prototype.handleItem = function handleItem (node, type, options){
 
 // Naive Stream API
 FeedParser.prototype._transform = function (data, encoding, done) {
+  if (!this.options.emit_meta_once) {
+    this._emitted_meta = false;
+  }
+
   this.stream.write(data);
   done();
 };

--- a/test/api.js
+++ b/test/api.js
@@ -31,14 +31,18 @@ describe('api', function () {
   it('should parse and set options', function (done) {
     var meta
       , item
-      , options = { normalize: false, addmeta: false };
+      , options = { normalize: false, addmeta: false, emit_meta_once: false }
+      , parser = FeedParser(options);
 
-    fs.createReadStream(feed).pipe(FeedParser(options))
-      .on('error', function (err) {
+    parser.on('error', function (err) {
         assert.ifError(err);
         done(err);
       })
       .on('meta', function (_meta) {
+        if (meta) {
+          // second pass through, test is now finished
+          done();
+        }
         meta = _meta;
       })
       .on('readable', function () {
@@ -50,8 +54,11 @@ describe('api', function () {
         assert.equal(meta.title, null);
         assert.equal(meta['rss:title']['#'], 'Liftoff News');
         assert.equal(item.meta, null);
-        done();
       });
+
+    fs.createReadStream(feed).pipe(parser);
+    fs.createReadStream(feed).pipe(parser);
+
   });
 
 });


### PR DESCRIPTION
Background: I'm writing an app that pulls data from RSS streams and writes it into a FeedParser, one whole feed at a time.

Problem: the `meta` event only fires once per FeedParser, meaning that no matter how many RSS feeds I shovel into a FeedReader, I only ever get one `meta` event.

Solution: this pull request implements a new option, `emit_meta_once`. By default it's set to true (the current behavior). If you set this to `false`, `this._emitted_meta` gets cleared on every `_write` so that downstream consumers can see a `meta` event for each feed XML string/buffer they shovel in.

I modified the tests to check the new behavior; all passing.
