### PR TITLE
removed resanitize and bumped the version on iconv to latest

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,7 @@ language: node_js
 node_js:
   - "0.8"
   - "0.10"
+  - "0.12"
 branches:
   only:
     - "master"

--- a/README.md
+++ b/README.md
@@ -16,7 +16,6 @@ that define a non-default namespace for the main feed elements).
 
 - [sax](https://github.com/isaacs/sax-js)
 - [addressparser](https://github.com/andris9/addressparser)
-- [resanitize](https://github.com/danmactough/node-resanitize)
 - [array-indexofobject](https://github.com/danmactough/node-array-indexofobject)
 - [readable-stream](https://github.com/isaacs/readable-stream) (only if using Node <= v0.8.x)
 

--- a/main.js
+++ b/main.js
@@ -12,11 +12,9 @@
 var sax = require('sax')
   , addressparser = require('addressparser')
   , indexOfObject = require('array-indexofobject')
-  , resanitize = require('resanitize')
   , util = require('util')
   , TransformStream = require('readable-stream').Transform
-  , utils = require('./utils')
-  ;
+  , utils = require('./utils');
 
 /**
  * FeedParser constructor. Most apps will only use one instance.
@@ -695,8 +693,8 @@ FeedParser.prototype.handleMeta = function handleMeta (node, type, options) {
     if (!meta.xmlurl && this.options.feedurl) {
       meta.xmlurl = meta.xmlUrl = this.options.feedurl;
     }
-    meta.title = meta.title && resanitize.stripHtml(meta.title);
-    meta.description = meta.description && resanitize.stripHtml(meta.description);
+    meta.title = meta.title && utils.stripHtml(meta.title);
+    meta.description = meta.description && utils.stripHtml(meta.description);
   }
 
   return meta;
@@ -1013,7 +1011,7 @@ FeedParser.prototype.handleItem = function handleItem (node, type, options){
         item.link = item.guid;
       }
     }
-    item.title = item.title && resanitize.stripHtml(item.title);
+    item.title = item.title && utils.stripHtml(item.title);
   }
   return item;
 };

--- a/package.json
+++ b/package.json
@@ -29,13 +29,12 @@
     "sax": "~0.6.0",
     "addressparser": "~0.1.3",
     "array-indexofobject": "~0.0.1",
-    "readable-stream": "~1.0.17",
-    "resanitize": "~0.3.0"
+    "readable-stream": "~1.0.17"
   },
   "devDependencies": {
     "mocha": "1.x",
     "request": "2.27.x",
-    "iconv": "2.0.x"
+    "iconv": "2.1.x"
   },
   "scripts": {
     "test": "./node_modules/mocha/bin/mocha"

--- a/utils.js
+++ b/utils.js
@@ -180,3 +180,17 @@ function reresolve (node, baseurl) {
   return resolveLevel(node);
 }
 exports.reresolve = reresolve;
+
+/*
+* Aggressivly strip HTML tags
+* Pulled out of node-resanitize because it was all that was being used
+* and it's way lighter...
+*
+* @param {String} str
+*/
+
+function stripHtml (str) {
+    return str.replace(/<.*?>/g, '');
+}
+
+exports.stripHtml = stripHtml;


### PR DESCRIPTION
Removed resanitizer as a dependency since the only thing in use was a 4 line function. Moved the function to utils. This was because there is a known vulnerability in one of resanitzer's dependencies ( [isUrl](https://nodesecurity.io/advisories/validator-isurl-denial-of-service) and [filter bypass](https://nodesecurity.io/advisories/validator_XSS_Filter_Bypass_via_Encoded_URL) ) that require a pretty substantial rework.

feedparser only uses the stripHtml function from resanitizer which is tiny (4 lines of code) and not effected by the vulnerabilities. So I pulled those out and put them in the utils.js file.

Also bumped iconv to latest because the version in the package.json didn't like node 0.12. 

All tests passing and should be ready to rock and roll.