### PR TITLE
HTML strip summaries

### DIFF
--- a/main.js
+++ b/main.js
@@ -1013,6 +1013,8 @@ FeedParser.prototype.handleItem = function handleItem (node, type, options){
       }
     }
     item.title = item.title && utils.stripHtml(item.title);
+    item.summary = item.summary && utils.stripHtml(item.summary);
+    item.description = item.description && utils.stripHtml(item.description);
   }
   return item;
 };

--- a/main.js
+++ b/main.js
@@ -694,6 +694,7 @@ FeedParser.prototype.handleMeta = function handleMeta (node, type, options) {
       meta.xmlurl = meta.xmlUrl = this.options.feedurl;
     }
     meta.title = meta.title && utils.stripHtml(meta.title);
+    meta.summary = meta.summary && utils.stripHtml(meta.summary);
     meta.description = meta.description && utils.stripHtml(meta.description);
   }
 


### PR DESCRIPTION
Since descriptions (```description``` key) gets HTML stripped with ```utils.stripHtml()```, I thought that summaries (```summary``` key) could get the same treatment as well.

This makes sense since the description value sometimes comes from the summary value:

https://github.com/danmactough/node-feedparser/blob/master/main.js#L732

I didn't write any tests for this but I can if it's a requirement for merging.