### PR TITLE
Be more careful about assigning item.link from atom:link elements

### DIFF
--- a/main.js
+++ b/main.js
@@ -787,7 +787,7 @@ FeedParser.prototype.handleItem = function handleItem (node, type, options){
             if (link['@']['href']) { // Atom
               if (utils.get(link['@'], 'rel')) {
                 if (link['@']['rel'] == 'canonical') item.origlink = link['@']['href'];
-                if (link['@']['rel'] == 'alternate') item.link = link['@']['href'];
+                if (link['@']['rel'] == 'alternate' && !item.link) item.link = link['@']['href'];
                 if (link['@']['rel'] == 'self' && !item.link) item.link = link['@']['href'];
                 if (link['@']['rel'] == 'replies') item.comments = link['@']['href'];
                 if (link['@']['rel'] == 'enclosure') {
@@ -810,7 +810,7 @@ FeedParser.prototype.handleItem = function handleItem (node, type, options){
           if (el['@']['href']) { // Atom
             if (utils.get(el['@'], 'rel')) {
               if (el['@']['rel'] == 'canonical') item.origlink = el['@']['href'];
-              if (el['@']['rel'] == 'alternate') item.link = el['@']['href'];
+              if (el['@']['rel'] == 'alternate' && !item.link) item.link = el['@']['href'];
               if (el['@']['rel'] == 'self' && !item.link) item.link = el['@']['href'];
               if (el['@']['rel'] == 'replies') item.comments = el['@']['href'];
               if (el['@']['rel'] == 'enclosure') {


### PR DESCRIPTION
Addresses #144

Publishers may omit the rel attribute from one link and still provide the rel=alternate link for another