### PR TITLE
Prefer atom link elements with type=text/html

### DIFF
--- a/main.js
+++ b/main.js
@@ -787,8 +787,8 @@ FeedParser.prototype.handleItem = function handleItem (node, type, options){
             if (link['@']['href']) { // Atom
               if (utils.get(link['@'], 'rel')) {
                 if (link['@']['rel'] == 'canonical') item.origlink = link['@']['href'];
-                if (link['@']['rel'] == 'alternate' && !item.link) item.link = link['@']['href'];
-                if (link['@']['rel'] == 'self' && !item.link) item.link = link['@']['href'];
+                if (link['@']['rel'] == 'alternate' && (!link['@']['type'] || link['@']['type'] == 'text/html') && !item.link) item.link = link['@']['href'];
+                if (link['@']['rel'] == 'self' && (!link['@']['type'] || link['@']['type'] == 'text/html') && !item.link) item.link = link['@']['href'];
                 if (link['@']['rel'] == 'replies') item.comments = link['@']['href'];
                 if (link['@']['rel'] == 'enclosure') {
                   enclosure = {};
@@ -810,8 +810,8 @@ FeedParser.prototype.handleItem = function handleItem (node, type, options){
           if (el['@']['href']) { // Atom
             if (utils.get(el['@'], 'rel')) {
               if (el['@']['rel'] == 'canonical') item.origlink = el['@']['href'];
-              if (el['@']['rel'] == 'alternate' && !item.link) item.link = el['@']['href'];
-              if (el['@']['rel'] == 'self' && !item.link) item.link = el['@']['href'];
+              if (el['@']['rel'] == 'alternate' && (!el['@']['type'] || el['@']['type'] == 'text/html') && !item.link) item.link = el['@']['href'];
+              if (el['@']['rel'] == 'self' && (!el['@']['type'] || el['@']['type'] == 'text/html') && !item.link) item.link = el['@']['href'];
               if (el['@']['rel'] == 'replies') item.comments = el['@']['href'];
               if (el['@']['rel'] == 'enclosure') {
                 enclosure = {};


### PR DESCRIPTION
This is related to #144 and #145. The current behavior accepts link elements with invalid type, for example if the feed includes the following items, then rel=self is used even though its type is *application/atom+xml*

```
<link rel='self' type='application/atom+xml' href='feed-item-url'/>
<link rel='alternate' type='text/html' href='blog-post-url'/>
```

This PR changes the behavior to prefer elements with type=text/html