### PR TITLE
Add option to pass custom data

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,6 +90,10 @@ for a very thorough working example.
   behavior. If you want total control over handling these errors and optionally
   aborting parsing the feed, use this option.
 
+- `customData` - Set to any arbitrary custom object that you wish to pass. Unless
+  `normalize` or `addmeta` are set to false, this object will be available to each 
+  parsed article through the `meta` property.
+
 ## Examples
 
 See the [`examples`](examples/) directory.

--- a/main.js
+++ b/main.js
@@ -412,6 +412,7 @@ FeedParser.prototype.handleMeta = function handleMeta (node, type, options) {
     meta.cloud = {};
     meta.image = {};
     meta.categories = [];
+    meta.customData = null;
   }
 
   Object.keys(node).forEach(function(name){
@@ -728,6 +729,10 @@ FeedParser.prototype.handleMeta = function handleMeta (node, type, options) {
     }
     meta.title = meta.title && utils.stripHtml(meta.title);
     meta.description = meta.description && utils.stripHtml(meta.description);
+    
+    if(this.options && this.options.customData) {
+      meta.customData = this.options.customData;
+    }
   }
 
   return meta;

--- a/test/api.js
+++ b/test/api.js
@@ -54,4 +54,31 @@ describe('api', function () {
       });
   });
 
+  it('should pass customData', function (done) {
+    var meta
+      , item
+      , options = { customData: { "hello": "world" }};  
+
+    fs.createReadStream(feed).pipe(FeedParser(options))
+      .on('error', function (err) {
+        assert.ifError(err);
+        done(err);
+      })
+      .on('meta', function (_meta) {
+        meta = _meta;
+      })
+      .on('readable', function () {
+        var _item = this.read();
+        item || (item = _item);
+      })
+      .on('end', function () {
+        assert(meta);
+        assert(meta.customData);
+        assert.equal(meta.customData.hello, "world");
+        assert(item.meta.customData);
+        assert.equal(item.meta.customData.hello, "world");
+        done();
+      });
+  })
+
 });


### PR DESCRIPTION
This adds the option to pass custom data to each parsed article through the `meta` property.