### PR TITLE
Handles line breaks in xml declaration.

### DIFF
--- a/main.js
+++ b/main.js
@@ -146,7 +146,7 @@ FeedParser.prototype.handleError = function (e){
 
 FeedParser.prototype.handleProcessingInstruction = function (node) {
   if (node.name !== 'xml') return;
-  this.meta['#xml'] = node.body.trim().split(' ').reduce(function (map, attr) {
+  this.meta['#xml'] = node.body.replace(/(\r\n|\n|\r)/gm," ").trim().split(' ').reduce(function (map, attr) {
     var parts = attr.split('=');
     map[parts[0]] = parts[1] && parts[1].length > 2 && parts[1].match(/^.(.*?).$/)[1];
     return map;


### PR DESCRIPTION
I came across a rss-feed with the following declaration:

```
<?xml version="1.0"
encoding="UTF-8" ?>
<rss version="0.91">
[...]
```

This breaks the handleProcessingInstruction function as it splits first by whitespace and then by '='. 
I'm not even sure if line breaks in the declaration are valid, but apparently they exist and fixing it is really simple.