### PR TITLE
Keep optional media:content attributes in the enclosures default property

### DIFF
--- a/lib/feedparser/index.js
+++ b/lib/feedparser/index.js
@@ -914,13 +914,23 @@ FeedParser.prototype.handleItem = function handleItem (node, type, options){
         }
         break;
       case('media:content'):
+        var optionalAttributes = ['bitrate', 'framerate', 'samplingrate', 'duration', 'height', 'width'];
         if (Array.isArray(el)) {
           el.forEach(function (enc){
             enclosure = {};
             enclosure.url = _.get(enc['@'], 'url');
             enclosure.type = _.get(enc['@'], 'type') || _.get(enc['@'], 'medium');
             enclosure.length = _.get(enc['@'], 'filesize');
-            if (indexOfObject(item.enclosures, enclosure, ['url', 'type']) === -1) {
+            var index = indexOfObject(item.enclosures, enclosure, ['url', 'type']);
+            if (index !== -1) {
+              enclosure = item.enclosures[index];
+            }
+            optionalAttributes.forEach(function (attribute) {
+              if (!enclosure[attribute] && _.get(enc['@'], attribute)) {
+                enclosure[attribute] = _.get(enc['@'], attribute);
+              }
+            });
+            if (index === -1) {
               item.enclosures.push(enclosure);
             }
           });
@@ -929,7 +939,16 @@ FeedParser.prototype.handleItem = function handleItem (node, type, options){
           enclosure.url = _.get(el['@'], 'url');
           enclosure.type = _.get(el['@'], 'type') || _.get(el['@'], 'medium');
           enclosure.length = _.get(el['@'], 'filesize');
-          if (indexOfObject(item.enclosures, enclosure, ['url', 'type']) === -1) {
+          var index = indexOfObject(item.enclosures, enclosure, ['url', 'type']);
+          if (index !== -1) {
+            enclosure = item.enclosures[index];
+          }
+          optionalAttributes.forEach(function (attribute) {
+            if (!enclosure[attribute] && _.get(el['@'], attribute)) {
+              enclosure[attribute] = _.get(el['@'], attribute);
+            }
+          });
+          if (index === -1) {
             item.enclosures.push(enclosure);
           }
         }

--- a/test/duplicate-enclosures.js
+++ b/test/duplicate-enclosures.js
@@ -6,7 +6,26 @@ describe('duplicate enclosures', function(){
     fs.createReadStream(feed).pipe(new FeedParser())
       .once('readable', function () {
         var stream = this;
-        assert.strictEqual(stream.read().enclosures.length, 2);
+        var enclosures = stream.read().enclosures;
+        assert.strictEqual(enclosures.length, 3);
+        assert.deepEqual(enclosures, [{
+          url: 'http://i.mol.im/i/pix/2013/02/03/article-2272640-174FCEE2000005DC-697_154x115.jpg',
+          type: 'image/jpeg',
+          length: '4114',
+          height: '115',
+          width: '154'
+        }, {
+          url: 'http://i.mol.im/i/pix/2013/02/03/article-2272640-174FCEE2000005DC-697_154x115.mp4',
+          type: 'video/mp4',
+          length: '4114'
+        }, {
+          url: 'http://i.mol.im/i/pix/2013/02/03/article-2272640-174FCEE2000005DC-697.mp4',
+          type: 'video/mp4',
+          length: null,
+          bitrate: '3000',
+          height: '115',
+          width: '154'
+        }]);
         done();
       })
       .on('error', function (err) {

--- a/test/feeds/mediacontent-dupes.xml
+++ b/test/feeds/mediacontent-dupes.xml
@@ -27,7 +27,8 @@
       <media:credit scheme="urn:ebu">© Bettmann/CORBIS</media:credit>
       <media:description type="html">Black Dahlia: A head shot of Elizabeth Short who had been an aspiring actress until her untimely murder</media:description>
       <media:thumbnail url="http://i.mol.im/i/pix/2013/02/03/article-2272640-174FCEE2000005DC-697_154x115.jpg" width="154" height="115" />
-      <media:content type="image/jpeg" url="http://i.mol.im/i/pix/2013/02/03/article-2272640-174FCEE2000005DC-697_154x115.jpg" />
+      <media:content type="image/jpeg" url="http://i.mol.im/i/pix/2013/02/03/article-2272640-174FCEE2000005DC-697_154x115.jpg" width="154" height="115"/>
+      <media:content type="video/mp4" url="http://i.mol.im/i/pix/2013/02/03/article-2272640-174FCEE2000005DC-697.mp4" width="154" height="115" bitrate="3000"/>
     </item>
   </channel>
 </rss>


### PR DESCRIPTION
Fixes https://github.com/danmactough/node-feedparser/issues/192