### PR TITLE
Create simple_collection

### DIFF
--- a/simple_collection
+++ b/simple_collection
@@ -1,0 +1,45 @@
+var FeedParser = require('feedparser');
+var request = require('request'); // for fetching the feed
+
+var req = request('http://somefeedurl.xml')
+var feedparser = new FeedParser([options]);
+
+//suggestion
+var collection = [];
+
+req.on('error', function (error) {
+  // handle any request errors
+});
+
+req.on('response', function (res) {
+  var stream = this; // `this` is `req`, which is a stream
+
+  if (res.statusCode !== 200) {
+    this.emit('error', new Error('Bad status code'));
+  }
+  else {
+    stream.pipe(feedparser);
+  }
+});
+
+feedparser.on('error', function (error) {
+  // always handle errors
+});
+
+feedparser.on('readable', function () {
+  // This is where the action is!
+  var stream = this; // `this` is `feedparser`, which is a stream
+  var meta = this.meta; // **NOTE** the "meta" is always available in the context of the feedparser instance
+  var item;
+
+  while (item = stream.read()) {
+    console.log(item);
+    collection.push(item);    //array of objects
+  }
+});
+
+//suggestion
+feedparser.on('end', function () {
+    console.log(collection);
+    //example usage: process data as collection for SQL usage
+});


### PR DESCRIPTION
Expanding on example usage "simple.js", we can prepare data as a collection. Once streaming "ends", the entire feed can be further processed as an array of objects (e.g. for working with database).