### PR TITLE
Fix reresolve helper to correctly resolve relative URLs in RSS channel image

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -118,6 +118,13 @@ function reresolve (node, baseurl) {
             if ('#' in level[el]) {
               level[el]['#'] = URL.resolve(baseurl, level[el]['#']);
             }
+          } else if (el == 'image') {
+            if ('url' in level[el] && level[el]['url'].constructor.name === 'Object' && '#' in level[el]['url']) {
+              level[el]['url']['#'] = URL.resolve(baseurl, level[el]['url']['#']);
+            }
+            if ('link' in level[el] && level[el]['link'].constructor.name === 'Object' && '#' in level[el]['link']) {
+              level[el]['link']['#'] = URL.resolve(baseurl, level[el]['link']['#']);
+            }
           } else if ('@' in level[el]) {
             var attrs = Object.keys(level[el]['@']);
             attrs.forEach(function (name) {

--- a/test/feeds/relative-channel-image-url.xml
+++ b/test/feeds/relative-channel-image-url.xml
@@ -1,0 +1,42 @@
+<?xml version="1.0"?>
+<rss xmlns:dc="http://purl.org/dc/elements/1.1/" version="2.0">
+  <channel>
+    <title>Oracle VM VirtualBox: Ticket #10860: Full resolution not exposed to Linux guest</title>
+    <link>https://www.virtualbox.org/ticket/10860</link>
+    <description>&lt;p&gt;
+When using &lt;a class="wiki" href="https://www.virtualbox.org/wiki/VirtualBox"&gt;VirtualBox&lt;/a&gt; on a MacBook Pro Retina, only half the resolution is exposed to, at least, Linux guests. This causes the fonts to be blurry in the guest OS.
+&lt;/p&gt;
+&lt;p&gt;
+To verify this, install Linux, and go to fullscreen, type xrandr and notice the resolution is set to 1440x900.
+&lt;/p&gt;
+&lt;p&gt;
+To compare with VMWare, full Retina mode is supported: &lt;a class="ext-link" href="http://www.vmware.com/products/fusion/features.html#approved"&gt;&lt;span class="icon"&gt; &lt;/span&gt;http://www.vmware.com/products/fusion/features.html#approved&lt;/a&gt;
+&lt;/p&gt;
+&lt;p&gt;
+This exposes the current full resolution to the guest, which in the default host retina mode would mean the guest sees 2880x1800 resolution and has to deal with it on its own accordingly.
+&lt;/p&gt;
+</description>
+    <language>en-us</language>
+    <image>
+      <title>Oracle VM VirtualBox</title>
+      <url>/graphics/vbox_logo2_gradient.png</url>
+      <link>https://www.virtualbox.org/ticket/10860</link>
+    </image>
+    <generator>Trac 0.12</generator>
+    <item>
+      
+        <dc:creator>dsvensson</dc:creator>
+
+      <pubDate>Fri, 24 Aug 2012 08:54:14 GMT</pubDate>
+      <title></title>
+      <link>https://www.virtualbox.org/ticket/10860#comment:1</link>
+      <guid isPermaLink="false">https://www.virtualbox.org/ticket/10860#comment:1</guid>
+      <description>
+        &lt;p&gt;
+The &lt;a class="wiki" href="https://www.virtualbox.org/wiki/VirtualBox"&gt;VirtualBox&lt;/a&gt; version is actually the 4.2 beta but it couldn't be selected.
+&lt;/p&gt;
+      </description>
+      <category>Ticket</category>
+    </item>
+ </channel>
+</rss>

--- a/test/xmlbase.js
+++ b/test/xmlbase.js
@@ -15,6 +15,19 @@ describe('xmlbase', function(){
       });
   });
 
+  it('should resolve relative image url in channel', function (done) {
+    var feed = __dirname + '/feeds/relative-channel-image-url.xml';
+    fs.createReadStream(feed).pipe(new FeedParser())
+      .on('meta', function (meta) {
+        assert.equal('https://www.virtualbox.org/graphics/vbox_logo2_gradient.png', meta.image.url);
+        done();
+      })
+      .on('error', function (err) {
+        assert.ifError(err);
+        done(err);
+      });
+  });
+
   it('should parse feedurl option and handle relative URIs with no root xml:base', function (done) {
     var feed = __dirname + '/feeds/intertwingly.atom';
     var options = { feedurl: 'http://intertwingly.net/blog/index.atom' };


### PR DESCRIPTION
Relative URLs are not acceptable here, but they happen.

Resolves #152