### PR TITLE
Improve relative url resolution in RSS feeds

### DIFF
--- a/lib/feedparser/index.js
+++ b/lib/feedparser/index.js
@@ -242,7 +242,15 @@ FeedParser.prototype.handleCloseTag = function (el){
     baseurl = this.xmlbase[0]['#'];
   }
 
-  if (baseurl && (node['#local'] === 'logo' || node['#local'] === 'icon') && node['#type'] === 'atom') {
+  var mayHaveResolvableUrl = (
+    (
+      (node['#local'] === 'logo' || node['#local'] === 'icon') && node['#type'] === 'atom'
+    ) ||
+    (
+      node['#local'] === 'link' // include rss:link, even though it should _never_ be a relative URL
+    )
+  );
+  if (baseurl && mayHaveResolvableUrl) {
     // Apply xml:base to these elements as they appear
     // rather than leaving it to the ultimate parser
     n['#'] = _.resolve(baseurl, n['#']);
@@ -454,9 +462,12 @@ FeedParser.prototype.handleMeta = function handleMeta (node, type, options) {
                 }
                 else if (link['@']['rel'] == 'self') {
                   meta.xmlurl = meta.xmlUrl = link['@']['href'];
-                  if (this.xmlbase && this.xmlbase.length === 0) {
-                    this.xmlbase.unshift({ '#name': 'xml', '#': meta.xmlurl});
+                  if (_.isAbsoluteUrl(meta.xmlurl) && this.xmlbase && this.xmlbase.length === 0) {
+                    this.xmlbase.unshift({ '#name': 'xml', '#': meta.xmlurl });
                     this.stack[0] = _.reresolve(this.stack[0], meta.xmlurl);
+                  }
+                  else if (this.xmlbase && this.xmlbase.length > 0) {
+                    meta.xmlurl = meta.xmlUrl = _.resolve(_.get(this.xmlbase[0], '#'), meta.xmlurl);
                   }
                 }
                 else if (link['@']['rel'] == 'hub' && !(meta.cloud.href || meta.cloud.domain)) {
@@ -469,9 +480,12 @@ FeedParser.prototype.handleMeta = function handleMeta (node, type, options) {
             } else if (Object.keys(link['@']).length === 0) { // RSS
               meta.link = _.get(link);
             }
-            if (meta.link && this.xmlbase && this.xmlbase.length === 0) {
+            if (_.isAbsoluteUrl(meta.link) && this.xmlbase && this.xmlbase.length === 0) {
               this.xmlbase.unshift({ '#name': 'xml', '#': meta.link});
               this.stack[0] = _.reresolve(this.stack[0], meta.link);
+            }
+            else if (this.xmlbase && this.xmlbase.length > 0) {
+              meta.link = _.resolve(_.get(this.xmlbase[0], '#'), meta.link);
             }
           }, this);
         } else {
@@ -482,9 +496,12 @@ FeedParser.prototype.handleMeta = function handleMeta (node, type, options) {
               }
               else if (el['@']['rel'] == 'self') {
                 meta.xmlurl = meta.xmlUrl = el['@']['href'];
-                if (this.xmlbase && this.xmlbase.length === 0) {
+                if (_.isAbsoluteUrl(meta.xmlurl) && this.xmlbase && this.xmlbase.length === 0) {
                   this.xmlbase.unshift({ '#name': 'xml', '#': meta.xmlurl});
                   this.stack[0] = _.reresolve(this.stack[0], meta.xmlurl);
+                }
+                else if (this.xmlbase && this.xmlbase.length > 0) {
+                  meta.xmlurl = meta.xmlUrl = _.resolve(_.get(this.xmlbase[0], '#'), meta.xmlurl);
                 }
               }
               else if (el['@']['rel'] == 'hub' && !(meta.cloud.href || meta.cloud.domain)) {
@@ -497,9 +514,12 @@ FeedParser.prototype.handleMeta = function handleMeta (node, type, options) {
           } else if (Object.keys(el['@']).length === 0) { // RSS
             if (!meta.link) meta.link = _.get(el);
           }
-          if (meta.link && this.xmlbase && this.xmlbase.length === 0) {
+          if (_.isAbsoluteUrl(meta.link) && this.xmlbase && this.xmlbase.length === 0) {
             this.xmlbase.unshift({ '#name': 'xml', '#': meta.link});
             this.stack[0] = _.reresolve(this.stack[0], meta.link);
+          }
+          else if (this.xmlbase && this.xmlbase.length > 0) {
+            meta.link = _.resolve(_.get(this.xmlbase[0], '#'), meta.link);
           }
         }
         break;
@@ -884,9 +904,12 @@ FeedParser.prototype.handleItem = function handleItem (node, type, options){
         }
         if (item.source['url'] && !this.meta.xmlurl) {
           this.meta.xmlurl = this.meta.xmlUrl = item.source['url'];
-          if (this.xmlbase && this.xmlbase.length === 0) {
+          if (_.isAbsoluteUrl(item.source['url']) && this.xmlbase && this.xmlbase.length === 0) {
             this.xmlbase.unshift({ '#name': 'xml', '#': item.source['url']});
             this.stack[0] = _.reresolve(this.stack[0], item.source['url']);
+          }
+          else if (this.xmlbase && this.xmlbase.length > 0) {
+            this.meta.xmlurl = this.meta.xmlUrl = item.source['url'] = _.resolve(_.get(this.xmlbase[0], '#'), item.source['url']);
           }
         }
         break;

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -55,13 +55,27 @@ function safeTrim (val) {
 exports.safeTrim = safeTrim;
 
 /*
- * Expose require('url').resolve
+ * Expose require('url').resolve, safely returning if either parameter
+ * isn't provided
  * @private
  */
 function resolve (baseUrl, pathUrl) {
+  if (!baseUrl || !pathUrl) return pathUrl;
   return URL.resolve(baseUrl, pathUrl);
 }
 exports.resolve = resolve;
+
+/*
+ * Check whether a given uri is an absolute URL
+ * @param {String} uri
+ * @private
+ */
+function isAbsoluteUrl (uri) {
+  if (!uri || typeof uri !== 'string') return false;
+  var parts = URL.parse(uri);
+  return Boolean(parts.host);
+}
+exports.isAbsoluteUrl = isAbsoluteUrl;
 
 /*
  * Check whether a given namespace URI matches the given default
@@ -114,7 +128,7 @@ function reresolve (node, baseurl) {
         });
       } else {
         if (level[el].constructor.name === 'Object') {
-          if (el == 'logo' || el == 'icon') {
+          if (el == 'logo' || el == 'icon' || el == 'link') {
             if ('#' in level[el]) {
               level[el]['#'] = URL.resolve(baseurl, level[el]['#']);
             }
@@ -125,7 +139,8 @@ function reresolve (node, baseurl) {
             if ('link' in level[el] && level[el]['link'].constructor.name === 'Object' && '#' in level[el]['link']) {
               level[el]['link']['#'] = URL.resolve(baseurl, level[el]['link']['#']);
             }
-          } else if ('@' in level[el]) {
+          }
+          if ('@' in level[el]) {
             var attrs = Object.keys(level[el]['@']);
             attrs.forEach(function (name) {
               if (name == 'href' || name == 'src' || name == 'uri') {

--- a/test/feeds/rss-with-relative-urls-with-absolute-xmlurl.xml
+++ b/test/feeds/rss-with-relative-urls-with-absolute-xmlurl.xml
@@ -1,0 +1,110 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?xml-stylesheet title="XSL_formatting" type="text/xsl" href="/nolsol.xsl"?>
+<rss xmlns:media="http://search.yahoo.com/mrss/" xmlns:atom="http://www.w3.org/2005/Atom" version="2.0">  
+  <channel> 
+    <title><![CDATA[Neverwinter]]></title>
+    <link>/en/games/neverwinter/news</link>  
+    <description><![CDATA[]]></description>  
+    <language>en_US</language>  
+    <lastBuildDate>Sun, 10 Dec 17 13:01:36 -0800</lastBuildDate>  
+    <copyright><![CDATA[
+	Copyright © 2017. Perfect World Entertainment Inc, All Rights Reserved.	]]></copyright>  
+    <image> 
+      <url>http://images-cdn.perfectworld.com/arc/0e/22/0e221ffcf7ab4eae547c72deecfc7be61501001169.png</url>
+      <title><![CDATA[Neverwinter]]></title>  
+      <link>/en/games/neverwinter/news</link>  
+    </image>  
+    <ttl>60</ttl>
+    <atom:link href="http://www.arcgames.com/en/games/neverwinter/news/rss" rel="self" type="application/rss+xml"/>
+        <item> 
+      <title><![CDATA[Neverwinter & Jingle Jam Humble Bundle!]]></title>  
+      <description><![CDATA[
+
+Greetings Adventurers!
+
+Neverwinter is proud to partner once again with Humble Bundle’s December Bundle – YogsCast Jingle Jam 2017! We are offering the Feywild Starter Pack (PC Only) as part of the latest bundle, starting on December 7 at 9am PT. This pack contains the Portal Hound Companion, Embroidered Elven Silk Bag, Feywild Hunter’s Ring, and the Adventurer’s Helper Pack.
+
+Your contributions last year went to some amazing organizations! This year, by purchasing the bundle and paying what you want, you can again help a mix of charities across a variety of causes! For more details, please clink on the link below.
+
+
+
+ ]]></description>  
+      <link>/en/games/neverwinter/news/detail/10743874-neverwinter-%26-jingle-jam-humble-bundle%21</link>
+      <guid isPermaLink="false">http://www.arcgames.com/en/games/PAB_nw/news/detail/10743874</guid>  
+      <pubDate>Thu, 07 Dec 17 10:00:29 -0800</pubDate>
+    </item>
+    <item> 
+      <title><![CDATA[2x Underdark Currency & 15% off Bags!]]></title>  
+      <description><![CDATA[
+
+Looking to make progress in the Underdark Campaign? This weekend you can earn 2x Underdark Campaign Currency! In addition, Bags will be 15% off! 
+
+2x Underdark Currency and 15% off Bags starts Thursday, December 7 at 7:30am PT (or after maintenance)
+
+2x Underdark Currency and 15% off Bags ends Monday, December 11 at 7:30am PT
+
+Underdark Currency can be obtained in Demonic Heroic Encounters, Throne of the Dwarven Gods, Prophecy of Madness, and Demogorgon!
+
+
+ 
+
+.share-link a {
+    margin: 0 10px 0 0;
+    background: url(http://images-cdn.perfectworld.com/arcportal_static/images/global/icon-social.png) no-repeat 0 0;
+    display: inline-block;
+    height: 30px;
+    width: 30px;
+    -webkit-box-shadow: 0 0 1px rgba(255,255,255,.9);
+    -moz-box-shadow: 0 0 1px rgba(255,255,255,.9);
+    box-shadow: 0 0 1px rgba(255,255,255,.9);
+    -webkit-border-radius: 2px;
+    -moz-border-radius: 2px;
+    border-radius: 2px;
+    padding: 0;
+    border: 1px solid transparent;
+}
+.share-link .youtube {
+    background-position: -60px 0;
+}
+.share-link .twitter {
+    background-position: -30px 0;
+}
+
+
+    
+
+.share-footer a {
+ margin: 20px 10px 10px 0;
+ background: url(http://images-cdn.perfectworld.com/arc/78/37/7837b2f61b4e186e6e19241cd6fe43491466535696.png)
+no-repeat 0 0;
+ opacity: .5;
+ display: inline-block;
+ height: 60px;
+ width: 60px;
+ padding: 0;
+ border: 1px solid transparent;
+ -webkit-transition: opacity .3s;
+ transition: opacity .3s;
+}
+.share-footer .TI { background-position: 0 20%; }
+.share-footer .YT { background-position: 0 40%; }
+.share-footer .YT { background-position: 0 40%; }
+.share-footer .TW { background-position: 0 60%; }
+.share-footer .FO { background-position: 0 80%; }
+.FB:hover { background-position: 100% 0%; }
+.TI:hover { background-position: 100% 20%; }
+.YT:hover { background-position: 100% 40%; }
+.TW:hover { background-position: 100% 60%; }
+.FO:hover { background-position: 100% 80%; }
+.share-footer a:hover {
+ opacity: 1;
+ -webkit-transition: opacity .3s;
+ transition: opacity .3s;
+}
+]]></description>  
+      <link>/en/games/neverwinter/news/detail/10738994-2x-underdark-currency-%26-15%25-off-bags%21</link>
+      <guid isPermaLink="false">http://www.arcgames.com/en/games/PAB_nw/news/detail/10738994</guid>  
+      <pubDate>Thu, 07 Dec 17 07:00:00 -0800</pubDate>
+    </item>
+  </channel> 
+</rss>

--- a/test/feeds/rss-with-relative-urls.xml
+++ b/test/feeds/rss-with-relative-urls.xml
@@ -1,0 +1,110 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?xml-stylesheet title="XSL_formatting" type="text/xsl" href="/nolsol.xsl"?>
+<rss xmlns:media="http://search.yahoo.com/mrss/" xmlns:atom="http://www.w3.org/2005/Atom" version="2.0">  
+  <channel> 
+    <title><![CDATA[Neverwinter]]></title>
+    <link>/en/games/neverwinter/news</link>  
+    <description><![CDATA[]]></description>  
+    <language>en_US</language>  
+    <lastBuildDate>Sun, 10 Dec 17 13:01:36 -0800</lastBuildDate>  
+    <copyright><![CDATA[
+	Copyright © 2017. Perfect World Entertainment Inc, All Rights Reserved.	]]></copyright>  
+    <image> 
+      <url>http://images-cdn.perfectworld.com/arc/0e/22/0e221ffcf7ab4eae547c72deecfc7be61501001169.png</url>
+      <title><![CDATA[Neverwinter]]></title>  
+      <link>/en/games/neverwinter/news</link>  
+    </image>  
+    <ttl>60</ttl>
+    <atom:link href="/en/games/neverwinter/news/rss" rel="self" type="application/rss+xml"/>
+        <item> 
+      <title><![CDATA[Neverwinter & Jingle Jam Humble Bundle!]]></title>  
+      <description><![CDATA[
+
+Greetings Adventurers!
+
+Neverwinter is proud to partner once again with Humble Bundle’s December Bundle – YogsCast Jingle Jam 2017! We are offering the Feywild Starter Pack (PC Only) as part of the latest bundle, starting on December 7 at 9am PT. This pack contains the Portal Hound Companion, Embroidered Elven Silk Bag, Feywild Hunter’s Ring, and the Adventurer’s Helper Pack.
+
+Your contributions last year went to some amazing organizations! This year, by purchasing the bundle and paying what you want, you can again help a mix of charities across a variety of causes! For more details, please clink on the link below.
+
+
+
+ ]]></description>  
+      <link>/en/games/neverwinter/news/detail/10743874-neverwinter-%26-jingle-jam-humble-bundle%21</link>
+      <guid isPermaLink="false">http://www.arcgames.com/en/games/PAB_nw/news/detail/10743874</guid>  
+      <pubDate>Thu, 07 Dec 17 10:00:29 -0800</pubDate>
+    </item>
+    <item> 
+      <title><![CDATA[2x Underdark Currency & 15% off Bags!]]></title>  
+      <description><![CDATA[
+
+Looking to make progress in the Underdark Campaign? This weekend you can earn 2x Underdark Campaign Currency! In addition, Bags will be 15% off! 
+
+2x Underdark Currency and 15% off Bags starts Thursday, December 7 at 7:30am PT (or after maintenance)
+
+2x Underdark Currency and 15% off Bags ends Monday, December 11 at 7:30am PT
+
+Underdark Currency can be obtained in Demonic Heroic Encounters, Throne of the Dwarven Gods, Prophecy of Madness, and Demogorgon!
+
+
+ 
+
+.share-link a {
+    margin: 0 10px 0 0;
+    background: url(http://images-cdn.perfectworld.com/arcportal_static/images/global/icon-social.png) no-repeat 0 0;
+    display: inline-block;
+    height: 30px;
+    width: 30px;
+    -webkit-box-shadow: 0 0 1px rgba(255,255,255,.9);
+    -moz-box-shadow: 0 0 1px rgba(255,255,255,.9);
+    box-shadow: 0 0 1px rgba(255,255,255,.9);
+    -webkit-border-radius: 2px;
+    -moz-border-radius: 2px;
+    border-radius: 2px;
+    padding: 0;
+    border: 1px solid transparent;
+}
+.share-link .youtube {
+    background-position: -60px 0;
+}
+.share-link .twitter {
+    background-position: -30px 0;
+}
+
+
+    
+
+.share-footer a {
+ margin: 20px 10px 10px 0;
+ background: url(http://images-cdn.perfectworld.com/arc/78/37/7837b2f61b4e186e6e19241cd6fe43491466535696.png)
+no-repeat 0 0;
+ opacity: .5;
+ display: inline-block;
+ height: 60px;
+ width: 60px;
+ padding: 0;
+ border: 1px solid transparent;
+ -webkit-transition: opacity .3s;
+ transition: opacity .3s;
+}
+.share-footer .TI { background-position: 0 20%; }
+.share-footer .YT { background-position: 0 40%; }
+.share-footer .YT { background-position: 0 40%; }
+.share-footer .TW { background-position: 0 60%; }
+.share-footer .FO { background-position: 0 80%; }
+.FB:hover { background-position: 100% 0%; }
+.TI:hover { background-position: 100% 20%; }
+.YT:hover { background-position: 100% 40%; }
+.TW:hover { background-position: 100% 60%; }
+.FO:hover { background-position: 100% 80%; }
+.share-footer a:hover {
+ opacity: 1;
+ -webkit-transition: opacity .3s;
+ transition: opacity .3s;
+}
+]]></description>  
+      <link>/en/games/neverwinter/news/detail/10738994-2x-underdark-currency-%26-15%25-off-bags%21</link>
+      <guid isPermaLink="false">http://www.arcgames.com/en/games/PAB_nw/news/detail/10738994</guid>  
+      <pubDate>Thu, 07 Dec 17 07:00:00 -0800</pubDate>
+    </item>
+  </channel> 
+</rss>

--- a/test/xmlbase.js
+++ b/test/xmlbase.js
@@ -67,4 +67,58 @@ describe('xmlbase', function(){
     });
   });
 
+  it('should resolve relative URI item links in RSS with feedurl option', function (done) {
+    var feed = __dirname + '/feeds/rss-with-relative-urls.xml';
+    var links = [];
+
+    fs.createReadStream(feed).pipe(new FeedParser({ feedurl: 'http://www.arcgames.com' }))
+      .on('readable', function () {
+        var item;
+        while ((item = this.read())) {
+          links.push(item.link);
+        }
+      })
+      .on('error', function (err) {
+        assert.ifError(err);
+        done(err);
+      })
+      .on('meta', function (meta) {
+        assert.equal('http://www.arcgames.com/en/games/neverwinter/news', meta.link);
+        assert.equal('http://www.arcgames.com/en/games/neverwinter/news/rss', meta.xmlurl);
+      })
+      .on('end', function () {
+        assert.equal(links[0], 'http://www.arcgames.com/en/games/neverwinter/news/detail/10743874-neverwinter-%26-jingle-jam-humble-bundle%21');
+        assert.equal(links[1], 'http://www.arcgames.com/en/games/neverwinter/news/detail/10738994-2x-underdark-currency-%26-15%25-off-bags%21');
+        assert.equal(links.length, 2);
+        done();
+      });
+  });
+
+  it('should resolve relative URI item links in RSS if absolute xmlurl is present', function (done) {
+    var feed = __dirname + '/feeds/rss-with-relative-urls-with-absolute-xmlurl.xml';
+    var links = [];
+
+    fs.createReadStream(feed).pipe(new FeedParser())
+      .on('readable', function () {
+        var item;
+        while ((item = this.read())) {
+          links.push(item.link);
+        }
+      })
+      .on('error', function (err) {
+        assert.ifError(err);
+        done(err);
+      })
+      .on('meta', function (meta) {
+        assert.equal('http://www.arcgames.com/en/games/neverwinter/news', meta.link);
+        assert.equal('http://www.arcgames.com/en/games/neverwinter/news/rss', meta.xmlurl);
+      })
+      .on('end', function () {
+        assert.equal(links[0], 'http://www.arcgames.com/en/games/neverwinter/news/detail/10743874-neverwinter-%26-jingle-jam-humble-bundle%21');
+        assert.equal(links[1], 'http://www.arcgames.com/en/games/neverwinter/news/detail/10738994-2x-underdark-currency-%26-15%25-off-bags%21');
+        assert.equal(links.length, 2);
+        done();
+      });
+  });
+
 });


### PR DESCRIPTION
It's totally ludicrous to have relative urls in RSS feeds, but it happens.

This improves our resolution of relative urls and adds a check that urls we add as the root xmlbase are actually absolute urls.

Resolves #171