### PR TITLE
Handle empty xml:base

### DIFF
--- a/lib/feedparser/index.js
+++ b/lib/feedparser/index.js
@@ -240,7 +240,7 @@ FeedParser.prototype.handleCloseTag = function (el){
   delete n['#prefix'];
   delete n['#uri'];
 
-  if (this.xmlbase && this.xmlbase.length) {
+  if (this.xmlbase && this.xmlbase.length && this.xmlbase[0]['#'].trim() !== '') {
     baseurl = this.xmlbase[0]['#'];
   }
 
@@ -316,7 +316,7 @@ FeedParser.prototype.handleCloseTag = function (el){
         this._emitted_meta = true;
       }
     }
-    if (!baseurl && this.xmlbase && this.xmlbase.length) { // handleMeta was able to infer a baseurl without xml:base or options.feedurl
+    if (!baseurl && this.xmlbase && this.xmlbase.length && this.xmlbase[0]['#'].trim() !== '') { // handleMeta was able to infer a baseurl without xml:base or options.feedurl
       n = _.reresolve(n, this.xmlbase[0]['#']);
     }
     item = this.handleItem(n, this.meta['#type'], this.options);

--- a/test/feeds/tpm-with-empty-base.atom
+++ b/test/feeds/tpm-with-empty-base.atom
@@ -1,0 +1,486 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<feed xml:base="" xml:lang="en-US" xmlns="http://www.w3.org/2005/Atom">
+  <id>tag:talkingpointsmemo.com,2005:/account/feed/all/LpNewCzTqYYiHqtKqyTw5DaF1aUucgyyXb2dsqKU2yMr</id>
+  <link rel="alternate" type="text/html" href="http://talkingpointsmemo.com"/>
+  <link rel="self" type="application/atom+xml" href="http://talkingpointsmemo.com/account/feed/all/LpNewCzTqYYiHqtKqyTw5DaF1aUucgyyXb2dsqKU2yMr"/>
+  <title>All TPM News</title>
+  <updated>2017-11-08T23:15:58Z</updated>
+  <entry>
+    <id>tag:talkingpointsmemo.com,2005:ArticleDecorator/270060</id>
+    <published>2017-11-08T18:15:58-05:00</published>
+    <updated>2017-11-08T18:15:58-05:00</updated>
+    <link rel="alternate" type="text/html" href="/livewire/hannity-announces-fox-hired-sebastian-gorka-national-security-strategist"/>
+    <title>Hannity Announces Fox Has Hired Sebastian Gorka As NatSec Strategist</title>
+    <content type="html">&lt;p&gt;Fox News star host Sean Hannity on Wednesday announced that the network has hired Sebastian Gorka, formerly deputy assistant to President Donald Trump and a counterterrorism adviser, as a national security strategist.&lt;/p&gt;
+&lt;p&gt;&amp;#8220;Joining us now is Dr. Sebastian Gorka,&amp;#8221; Hannity said on his &lt;a href="https://www.mediamatters.org/video/2017/11/08/sean-hannity-announces-his-radio-show-fox-news-has-hired-former-trump-adviser-sebastian-gorka/218492"&gt;radio show&lt;/a&gt;. &amp;#8220;I can officially announce today he is a Fox News national security strategist.&amp;#8221;&lt;/p&gt;
+&lt;p&gt;&amp;#8220;It&amp;#8217;s in large part, really, thanks to you, Sean,&amp;#8221; Gorka replied. &amp;#8220;You&amp;#8217;ve been a great supporter, not only of myself, but of the administration and the President, and it&amp;#8217;s great to be back as part of the superb Fox family.&amp;#8221;&lt;/p&gt;
+&lt;p&gt;A Fox spokesperson confirmed to TPM by email that the network has hired Gorka for that position.&lt;/p&gt;
+&lt;p&gt;Gorka &lt;a href="http://talkingpointsmemo.com/livewire/gorka-out-white-house-disputes-claim-did-not-resign"&gt;left his position&lt;/a&gt; at the White House in August. He &lt;a href="https://www.apnews.com/d7b38219387e418ab187617f709fad28"&gt;claimed to the Associated Press&lt;/a&gt; that he resigned, but an unnamed White House official told a pool reporter that Gorka &amp;#8220;did not resign&amp;#8221; but &amp;#8220;no longer works at the White House.&amp;#8221;&lt;/p&gt;
+&lt;p&gt;Gorka&amp;#8217;s &lt;a href="http://talkingpointsmemo.com/livewire/sebastian-gorka-role-boston-bombing-trial-limited"&gt;dubious credentials&lt;/a&gt; as a &lt;a href="http://talkingpointsmemo.com/dc/sebastian-gorka-washington-experts-dc-anti-islam-ties"&gt;self-proclaimed expert&lt;/a&gt; on counterterrorism and his history of Islamophobic rhetoric drew calls for his removal months before he left Trump&amp;#8217;s administration.&lt;/p&gt;</content>
+    <author>
+      <name>Esme Cribb</name>
+    </author>
+  </entry>
+  <entry>
+    <id>tag:talkingpointsmemo.com,2005:ArticleDecorator/270059</id>
+    <published>2017-11-08T18:02:40-05:00</published>
+    <updated>2017-11-08T18:02:40-05:00</updated>
+    <link rel="alternate" type="text/html" href="/edblog/were-hiring-senior-editor"/>
+    <title>We're Hiring: Senior Editor</title>
+    <content type="html">&lt;p&gt;TPM is currently hiring for four editorial positions, one existing position and three new positions: Senior Editor, Prime Editor, Assistant Editor and a third reporter to join our Investigations Desk team. I&amp;#8217;ll be posting job listings for all of these positions shortly. But I wanted to start with the Senior Editor listing, an existing position based out of our New York office.&lt;/p&gt;
+&lt;p&gt;Listing after the jump.
+
+&lt;/p&gt;
+&lt;p&gt;SENIOR EDITOR&lt;/p&gt;
+&lt;p&gt;TPM is seeking a senior editor to lead a team of reporters in deep, immersive, fast-paced coverage of US politics, policy, and related coverage areas. The position requires strong leadership and diplomacy skills, the ability to engage and inspire your team, and the desire to work in a highly collaborative setting on new and innovative ways to tell stories.&lt;/p&gt;
+&lt;p&gt;Outstanding news judgment, a strong grasp of US politics, the ability to juggle stories of multiple lengths and varying levels of complexity, and a sharp sense of humor are all required. The senior editor will have a significant role in helping to direct overall news coverage and manage the editorial team.&lt;/p&gt;
+&lt;p&gt;A minimum of seven years of professional editing and/or reporting experience is required.&lt;/p&gt;
+&lt;p&gt;The position is based in either NYC or DC. It offers health insurance coverage, 401(k), and three weeks paid vacation per year.  To apply, send a resume and cover letter to jobs (at) talkingpointsmemo.com. Include the subject line: “Job App: Senior Editor”.&lt;/p&gt;
+&lt;p&gt;Women and minorities are encouraged to apply.&lt;/p&gt;</content>
+    <author>
+      <name>Josh Marshall</name>
+    </author>
+  </entry>
+  <entry>
+    <id>tag:talkingpointsmemo.com,2005:ArticleDecorator/270058</id>
+    <published>2017-11-08T17:16:14-05:00</published>
+    <updated>2017-11-08T17:16:14-05:00</updated>
+    <link rel="alternate" type="text/html" href="/news/menendez-no-verdict-second-day-deliberations"/>
+    <title>Menendez 'Convinced' He Will Be Exonerated After 2nd Day Sans Verdict</title>
+    <content type="html">&lt;p&gt;NEWARK, N.J. (AP) — Jurors finished a second full day of deliberations without reaching a verdict Wednesday in the bribery trial of U.S. Sen. Bob Menendez and gave no indication as to which way they might be leaning or what legal issues they are pondering in the jury room.&lt;/p&gt;
+&lt;p&gt;The only request they made to the judge came shortly after they arrived in the morning, when they asked to leave an hour earlier because of &amp;#8220;horrific traffic jams&amp;#8221; leaving Newark the day before.&lt;/p&gt;
+&lt;p&gt;Outside the courthouse, Menendez expressed confidence.&lt;/p&gt;
+&lt;p&gt;&amp;#8220;I have every expectation that based upon all of the facts that have been presented at this trial, if they listen to the law and the facts, I am convinced we will be exonerated, and that&amp;#8217;s worth waiting for.&amp;#8221;&lt;/p&gt;
+&lt;p&gt;The New Jersey Democrat is charged with accepting gifts from Florida eye doctor Salomon Melgen over several years in exchange for helping Melgen advance his business interests by exerting pressure on government officials. The two men face multiple bribery and fraud charges, and Menendez also is charged with making false statements on Senate forms by not disclosing Melgen&amp;#8217;s gifts.&lt;/p&gt;
+&lt;p&gt;The makeup of the Senate could be affected if Menendez is convicted and then voted out by a two-thirds majority, a prospect considered unlikely since it would require more than a dozen Democrats to join the Republican majority.&lt;/p&gt;
+&lt;p&gt;If Menendez were removed from the Senate, his replacement would be selected by the governor. Democrat Phil Murphy was elected New Jersey governor Tuesday night and will replace Republican Chris Christie in January.&lt;/p&gt;
+&lt;p&gt;Jury deliberations could experience a hiccup if a verdict isn&amp;#8217;t reached by the end of Thursday. The judge has said at that time he will excuse a juror who has an approaching scheduling conflict. In that case, an alternate would replace her and deliberations would start over.&lt;/p&gt;
+&lt;p&gt;The jury began deliberations late Monday afternoon after hearing nearly eight hours of attorneys&amp;#8217; closing arguments and roughly nine weeks of testimony. They were sent out of the room several times during the trial so attorneys on both sides could engage in legal mud-wrestling over the finer points of federal bribery statutes.&lt;/p&gt;
+&lt;p&gt;Many of the disputes arose because Menendez&amp;#8217;s trial is the first major federal corruption trial since a 2016 U.S. Supreme Court ruling narrowed the definition of what constitutes an &amp;#8220;official act&amp;#8221; in a bribery scheme and raised the bar for bribery prosecutions.&lt;/p&gt;
+&lt;p&gt;Walls rejected defense attorneys&amp;#8217; arguments that the Supreme Court ruling invalidated the so-called &amp;#8220;stream of benefits&amp;#8221; theory, in which specific gifts need not be tied to specific official actions to be considered bribes. Instead, they focused in closing arguments on language from the ruling that requires Menendez to have agreed to take official action at the time a bribery agreement was made.&lt;/p&gt;
+&lt;p&gt;They claim the prosecution didn&amp;#8217;t present evidence of an explicit agreement between the two men. Prosecutors countered that they were only required to demonstrate an implicit agreement.&lt;/p&gt;</content>
+    <author>
+      <name>DAVID PORTER</name>
+    </author>
+  </entry>
+  <entry>
+    <id>tag:talkingpointsmemo.com,2005:ArticleDecorator/270057</id>
+    <published>2017-11-08T17:05:47-05:00</published>
+    <updated>2017-11-08T17:05:47-05:00</updated>
+    <link rel="alternate" type="text/html" href="/livewire/cbo-estimate-individual-mandate-13-million-2027"/>
+    <title>CBO: 13 Million More Uninsured By 2027 If Individual Mandate Repealed</title>
+    <content type="html">&lt;p&gt;Repealing Obamacare’s individual mandate would increase the number of uninsured people by 13 million by 2027, the Congressional Budget Office said &lt;a href="https://www.cbo.gov/publication/53300"&gt;in a new estimate Wednesday&lt;/a&gt;.&lt;/p&gt;
+&lt;p&gt;Earlier this month, the White House and some in Congress briefly floated that they would try to repeal the individual mandate as part of Republicans’ tax cut proposal. The idea &lt;a href="http://talkingpointsmemo.com/dc/trumps-call-for-repealing-obamacare-mandate-in-tax-bill-lands-with-a-thud"&gt;landed with a thud&lt;/a&gt;. Republicans in both chambers have repeatedly attempted to pass legislation to erase former President Barack Obama&amp;#8217;s signature legislative achievement, to little avail and increasing frustration from the Trump administration.&lt;/p&gt;
+&lt;p&gt;According to the CBO, repealing the individual mandate would save $338 billion between 2018 and 2027. Four million more people would be uninsured by 2019 as a result of the mandate’s repeal, the CBO said.&lt;/p&gt;
+&lt;p&gt;The CBO further estimated that a mandate repeal would increase premiums 10 percent “in most years” of the following decade, relative to the office’s baseline projections.&lt;/p&gt;
+&lt;p&gt;The non-partisan office, whose analyses of the effects of Republicans’ Obamacare repeal efforts have come under partisan attack in recent months, said the estimate was not based on specific legislative language, but rather on the prospect of simply removing penalties for individuals without insurance coverage who are not exempt from the mandate under the current law.&lt;/p&gt;
+&lt;p&gt;The analysis was completed alongside the staff of the Joint Committee on Taxation, the CBO said.&lt;/p&gt;</content>
+    <author>
+      <name>Matt Shuham</name>
+    </author>
+  </entry>
+  <entry>
+    <id>tag:talkingpointsmemo.com,2005:ArticleDecorator/270056</id>
+    <published>2017-11-08T16:57:47-05:00</published>
+    <updated>2017-11-08T16:57:47-05:00</updated>
+    <link rel="alternate" type="text/html" href="/news/trump-dhs-nominee-not-determine-climate-change-man-made"/>
+    <title>Trump DHS Pick 'Can't Unequivocally State' Climate Change Is Man-Made</title>
+    <content type="html">&lt;p&gt;WASHINGTON (AP) — President Donald Trump&amp;#8217;s choice to head the Department of Homeland Security said Wednesday that she believes climate change exists, but said she cannot determine whether humans are the primary cause.&lt;/p&gt;
+&lt;p&gt;Speaking at her Senate confirmation hearing, Kirstjen Nielsen said she is &amp;#8220;not prepared to determine causation&amp;#8221; on climate change.&lt;/p&gt;
+&lt;p&gt;Nielsen&amp;#8217;s comment contradicts mainstream climate science, including a U.S. report last week that concludes the evidence of global warming is stronger than ever and that it&amp;#8217;s &amp;#8220;extremely likely&amp;#8221; — meaning with 95 to 100 percent certainty — that global warming is man-made.&lt;/p&gt;
+&lt;p&gt;As head of homeland security, Nielsen would oversee a sprawling agency that leads the federal response to a range of natural disasters from wildfires to hurricanes.&lt;/p&gt;
+&lt;p&gt;Democrats criticized Nielsen&amp;#8217;s answer, which is in line with top Trump administration officials who downplay humans&amp;#8217; role in climate change.&lt;/p&gt;
+&lt;p&gt;Sen. Tom Carper, D-Del., said his state is &amp;#8220;sinking&amp;#8221; as oceans rise. He called Nielsen&amp;#8217;s comment troubling. &amp;#8220;Ninety-eight percent of our scientists say this is a problem and we as humans are the root cause,&amp;#8221; Carper said.&lt;/p&gt;
+&lt;p&gt;Sen. Maggie Hassan, D-N.H., urged Nielsen to &amp;#8220;educate yourself&amp;#8221; about climate change, adding &amp;#8220;What I heard in your answer is politics before science. That concerns me greatly.&amp;#8221;&lt;/p&gt;
+&lt;p&gt;Nielsen, a former Homeland security official who now serves as deputy White House chief of staff, told the Senate Homeland Security Committee that she agrees climate change is important and said the Trump administration is revising its climate models to better respond to rising sea levels.&lt;/p&gt;
+&lt;p&gt;&amp;#8220;I can&amp;#8217;t unequivocally state it&amp;#8217;s caused by humans,&amp;#8221; she said. &amp;#8220;There are many contributions to it.&amp;#8221;&lt;/p&gt;
+&lt;p&gt;A 1,500-page draft report by the U.S. Global Change Research Program said global warming is already sickening, injuring and killing Americans with changes to weather, food, air, water and diseases. And it&amp;#8217;s expected to get worse, hurting the economy, wildlife and energy supply, the report said.&lt;/p&gt;
+&lt;p&gt;On other topics, Nielsen said she agreed with former Homeland Security Secretary John Kelly — now White House chief of staff — that a U.S.-Mexico border wall is unlikely to be a physical barrier from &amp;#8220;sea to shining sea.&amp;#8221;&lt;/p&gt;
+&lt;p&gt;She also condemned white nationalism and refuted Islamophobia and promised to make cybersecurity a top priority.&lt;/p&gt;
+&lt;p&gt;Nielsen, a former staffer at the DHS, said the scope and pace of cyberattacks on federal networks and critical infrastructure are &amp;#8220;continually increasing&amp;#8221; and grow more complex and sophisticated each day. She said threats to the homeland &amp;#8220;are too many and too varied&amp;#8221; for any one agency to confront alone and pledged to work across government and the private sector to find solutions.&lt;/p&gt;
+&lt;p&gt;Trump nominated Nielsen last month to succeed Kelly. He and others in the administration have spoken about the geographical and logistical obstacles to building a massive wall along the border. Trump repeatedly promised during the campaign that he would build the wall and that Mexico would pay for it, but the administration is seeking billions in taxpayer dollars to finance the project.&lt;/p&gt;
+&lt;p&gt;Homeland Security has been leading the charge on implementing Trump&amp;#8217;s aggressive immigration agenda, and Nielsen pledged to continue that work.&lt;/p&gt;
+&lt;p&gt;&amp;#8220;I will work every day to enforce ours laws, secure our borders, coasts and waterways and protect Americans from dangerous criminals, terrorists, cyberattacks and other threats,&amp;#8221; she said.&lt;/p&gt;
+&lt;p&gt;After Hurricane Katrina struck the Gulf Coast in 2005, Nielsen led an effort to revise disaster-response and recovery plans, work that drew praise from former Homeland Security Secretary Michael Chertoff.&lt;/p&gt;
+&lt;p&gt;But Nielsen&amp;#8217;s involvement in Katrina came under harsh scrutiny a decade ago.&lt;/p&gt;
+&lt;p&gt;Reports issued two years later by Congress were highly critical of the Bush administration&amp;#8217;s handling of the storm. The reports faulted the White House Homeland Security Council — where Nielsen directed preparedness and response — for failing to take the lead in staying on top of the unfolding disaster.&lt;/p&gt;
+&lt;p&gt;Missouri Sen. Claire McCaskill, the committee&amp;#8217;s top Democrat, said she hopes Nielsen applies lessons learned from Katrina and other disasters to improve oversight of DHS contracting practices.&lt;/p&gt;</content>
+    <author>
+      <name>MATTHEW DALY</name>
+    </author>
+  </entry>
+  <entry>
+    <id>tag:talkingpointsmemo.com,2005:ArticleDecorator/270055</id>
+    <published>2017-11-08T16:14:24-05:00</published>
+    <updated>2017-11-08T16:14:24-05:00</updated>
+    <link rel="alternate" type="text/html" href="/livewire/fox-news-buries-head-in-the-sand-republicans-election-loss"/>
+    <title>Fox News Buries Its Head In The Sand After State-Level Bloodbath For GOP</title>
+    <content type="html">&lt;p&gt;After Democrats swept state-level elections on Tuesday night to win decisive victories from coast to coast, Fox News appeared to seek bliss in ignorance.&lt;/p&gt;
+&lt;p&gt;The network&amp;#8217;s star host Tucker Carlson sounded maudlin as he announced that the network was calling Virginia&amp;#8217;s gubernatorial race for Democratic candidate Virginia Lt. Gov. Ralph Northam (D), breaking the news without any of his usual abrasive bombast.&lt;/p&gt;
+&lt;p&gt;&amp;#8220;We&amp;#8217;ve got breaking news here. Okay. We are now reporting that Ralph Northam has won the Virginia governor&amp;#8217;s race,&amp;#8221; Carlson said. &amp;#8220;Ralph Northam, the Democrat, beating Ed Gillespie. With 58 percent in, we are projecting that he is the winner tonight.&amp;#8221;&lt;/p&gt;
+&lt;blockquote class="twitter-tweet" data-width="550"&gt;
+&lt;p lang="en" dir="ltr"&gt;Harrowing, bracing moment when Tucker Carlson shapeshifted into an actual sad trombone and was forced to declare Northam the winner. &lt;a href="https://t.co/LmzsBB7RYT"&gt;pic.twitter.com/LmzsBB7RYT&lt;/a&gt;&lt;/p&gt;
+&lt;p&gt;&amp;mdash; Josh Marshall (@joshtpm) &lt;a href="https://twitter.com/joshtpm/status/928134374519988225?ref_src=twsrc%5Etfw"&gt;November 8, 2017&lt;/a&gt;&lt;/p&gt;&lt;/blockquote&gt;
+&lt;p&gt;&lt;script async src="https://platform.twitter.com/widgets.js" charset="utf-8"&gt;&lt;/script&gt;&lt;/p&gt;
+&lt;p&gt;Fox News host Sean Hannity promised to cover election results on his show, but ultimately did so for all of six seconds.&lt;/p&gt;
+&lt;blockquote class="twitter-tweet" data-width="550"&gt;
+&lt;p lang="en" dir="ltr"&gt;Tonight on &lt;a href="https://twitter.com/hashtag/Hannity?src=hash&amp;amp;ref_src=twsrc%5Etfw"&gt;#Hannity&lt;/a&gt; we will cover President Trump’s speech in South Korea and election results with &lt;a href="https://twitter.com/SebGorka?ref_src=twsrc%5Etfw"&gt;@SebGorka&lt;/a&gt;, &lt;a href="https://twitter.com/AmbJohnBolton?ref_src=twsrc%5Etfw"&gt;@AmbJohnBolton&lt;/a&gt;, &lt;a href="https://twitter.com/peterschweizer?ref_src=twsrc%5Etfw"&gt;@peterschweizer&lt;/a&gt;, &lt;a href="https://twitter.com/MonicaCrowley?ref_src=twsrc%5Etfw"&gt;@MonicaCrowley&lt;/a&gt;, &lt;a href="https://twitter.com/GreggJarrett?ref_src=twsrc%5Etfw"&gt;@GreggJarrett&lt;/a&gt; and more&lt;/p&gt;
+&lt;p&gt;&amp;mdash; Sean Hannity (@seanhannity) &lt;a href="https://twitter.com/seanhannity/status/928071287590793217?ref_src=twsrc%5Etfw"&gt;November 8, 2017&lt;/a&gt;&lt;/p&gt;&lt;/blockquote&gt;
+&lt;p&gt;&lt;script async src="https://platform.twitter.com/widgets.js" charset="utf-8"&gt;&lt;/script&gt;&lt;/p&gt;
+&lt;p&gt;&amp;#8220;Let&amp;#8217;s talk about those results in Virginia, New Jersey, New York, by the way,&amp;#8221; Hannity said, listing states that Democrats won, and added for the network&amp;#8217;s most prominent viewer, &amp;#8220;Not states Donald Trump won.&amp;#8221;&lt;/p&gt;
+&lt;blockquote class="twitter-tweet" data-width="550"&gt;
+&lt;p lang="en" dir="ltr"&gt;Hannity doesn&amp;#39;t appear to be planning to cover the Virginia election at all. This was it. It lasted 6 seconds. &lt;a href="https://t.co/AnpvcicXMT"&gt;pic.twitter.com/AnpvcicXMT&lt;/a&gt;&lt;/p&gt;
+&lt;p&gt;&amp;mdash; Judd Legum (@JuddLegum) &lt;a href="https://twitter.com/JuddLegum/status/928082379725594624?ref_src=twsrc%5Etfw"&gt;November 8, 2017&lt;/a&gt;&lt;/p&gt;&lt;/blockquote&gt;
+&lt;p&gt;&lt;script async src="https://platform.twitter.com/widgets.js" charset="utf-8"&gt;&lt;/script&gt;&lt;/p&gt;
+&lt;p&gt;Hannity then dropped the subject for the rest of his show.&lt;/p&gt;
+&lt;p&gt;Newly minted Fox News host and conservative radio host Laura Ingraham spared Republican nominee Ed Gillespie a brief mention, and somehow managed to bring up Hillary Clinton&amp;#8217;s use of a private email server as secretary of state.&lt;/p&gt;
+&lt;p&gt;Clinton was not running for office on Tuesday, and &lt;a href="http://talkingpointsmemo.com/livewire/hillary-clinton-says-she-is-done-with-being-a-candidate"&gt;has said&lt;/a&gt; she is &amp;#8220;done with being a candidate.&amp;#8221;&lt;/p&gt;
+&lt;blockquote class="twitter-tweet" data-width="550"&gt;
+&lt;p lang="en" dir="ltr"&gt;the segment lasts 4 minutes, max. we go to commercial break. that&amp;#39;s it.&lt;/p&gt;
+&lt;p&gt;&amp;mdash; chris hooks (@cd_hooks) &lt;a href="https://twitter.com/cd_hooks/status/928108861571158016?ref_src=twsrc%5Etfw"&gt;November 8, 2017&lt;/a&gt;&lt;/p&gt;&lt;/blockquote&gt;
+&lt;p&gt;&lt;script async src="https://platform.twitter.com/widgets.js" charset="utf-8"&gt;&lt;/script&gt;&lt;/p&gt;
+&lt;p&gt;Shannon Bream, host of &amp;#8220;Fox News Tonight,&amp;#8221; similarly managed to bring up the firm behind the so-called Trump dossier that alleges ties between Trump&amp;#8217;s campaign and Russia, a document which played no part in Tuesday&amp;#8217;s elections.&lt;/p&gt;
+&lt;blockquote class="twitter-tweet" data-width="550"&gt;
+&lt;p lang="en" dir="ltr"&gt;Fox RN &lt;a href="https://t.co/WpfPKco92A"&gt;pic.twitter.com/WpfPKco92A&lt;/a&gt;&lt;/p&gt;
+&lt;p&gt;&amp;mdash; Rick Wilson (@TheRickWilson) &lt;a href="https://twitter.com/TheRickWilson/status/928114530193952768?ref_src=twsrc%5Etfw"&gt;November 8, 2017&lt;/a&gt;&lt;/p&gt;&lt;/blockquote&gt;
+&lt;p&gt;&lt;script async src="https://platform.twitter.com/widgets.js" charset="utf-8"&gt;&lt;/script&gt;&lt;/p&gt;
+&lt;p&gt;On Wednesday morning, the network continued its myopic focus on anything but the previous day&amp;#8217;s elections.&lt;/p&gt;
+&lt;blockquote class="twitter-tweet" data-width="550"&gt;
+&lt;p lang="en" dir="ltr"&gt;Fox News has nothing on Virginia this morning, instead they are replaying election night 2016 highlights.&lt;/p&gt;
+&lt;p&gt;&amp;mdash; Conn Carroll (@conncarroll) &lt;a href="https://twitter.com/conncarroll/status/928254727883771904?ref_src=twsrc%5Etfw"&gt;November 8, 2017&lt;/a&gt;&lt;/p&gt;&lt;/blockquote&gt;
+&lt;p&gt;&lt;script async src="https://platform.twitter.com/widgets.js" charset="utf-8"&gt;&lt;/script&gt;&lt;/p&gt;
+&lt;blockquote class="twitter-tweet" data-width="550"&gt;
+&lt;p lang="en" dir="ltr"&gt;Finding election coverage on the Fox News website right now is like trying to find Waldo. &lt;a href="https://t.co/3Tw4NkoY1u"&gt;pic.twitter.com/3Tw4NkoY1u&lt;/a&gt;&lt;/p&gt;
+&lt;p&gt;&amp;mdash; Matthew Gertz (@MattGertz) &lt;a href="https://twitter.com/MattGertz/status/928304458584481792?ref_src=twsrc%5Etfw"&gt;November 8, 2017&lt;/a&gt;&lt;/p&gt;&lt;/blockquote&gt;
+&lt;p&gt;&lt;script async src="https://platform.twitter.com/widgets.js" charset="utf-8"&gt;&lt;/script&gt;&lt;/p&gt;
+&lt;p&gt;As of Wednesday afternoon, Fox News&amp;#8217; homepage had just two references to the previous day&amp;#8217;s elections, both relegated to the page&amp;#8217;s periphery.&lt;/p&gt;
+&lt;p&gt;&lt;img class="aligncenter size-large wp-image-1094583" src="https://dawm7kda6y2v0.cloudfront.net/uploads/2017/11/Screen-Shot-2017-11-08-at-3.43.12-PM-804x501-874f980.png" alt="" width="804" height="501" srcset="https://dawm7kda6y2v0.cloudfront.net/uploads/2017/11/Screen-Shot-2017-11-08-at-3.43.12-PM-804x501-874f980.png 804w, https://dawm7kda6y2v0.cloudfront.net/uploads/2017/11/Screen-Shot-2017-11-08-at-3.43.12-PM-600x374-9f7a0b6.png 600w, https://dawm7kda6y2v0.cloudfront.net/uploads/2017/11/Screen-Shot-2017-11-08-at-3.43.12-PM-1000x623-351a115.png 1000w, https://dawm7kda6y2v0.cloudfront.net/uploads/2017/11/Screen-Shot-2017-11-08-at-3.43.12-PM.png 1532w, https://dawm7kda6y2v0.cloudfront.net/uploads/2017/11/Screen-Shot-2017-11-08-at-3.43.12-PM-600x374-9f7a0b6@2x.png 1200w" sizes="(max-width: 804px) 100vw, 804px" /&gt;&lt;/p&gt;
+&lt;p&gt;On top of it all, the cable network ran a chyron about Gillespie&amp;#8217;s loss that was strikingly similar to President Donald Trump&amp;#8217;s criticism of the candidate&amp;#8217;s strategy.&lt;/p&gt;
+&lt;blockquote class="twitter-tweet" data-width="550"&gt;
+&lt;p lang="en" dir="ltr"&gt;CNN vs. Fox: A tale of two chyrons &lt;a href="https://t.co/GOxfbBE18n"&gt;pic.twitter.com/GOxfbBE18n&lt;/a&gt;&lt;/p&gt;
+&lt;p&gt;&amp;mdash; Lis Power (@LisPower1) &lt;a href="https://twitter.com/LisPower1/status/928322907633258496?ref_src=twsrc%5Etfw"&gt;November 8, 2017&lt;/a&gt;&lt;/p&gt;&lt;/blockquote&gt;
+&lt;p&gt;&lt;script async src="https://platform.twitter.com/widgets.js" charset="utf-8"&gt;&lt;/script&gt;&lt;/p&gt;</content>
+    <author>
+      <name>Esme Cribb</name>
+    </author>
+  </entry>
+  <entry>
+    <id>tag:talkingpointsmemo.com,2005:ArticleDecorator/270054</id>
+    <published>2017-11-08T15:16:06-05:00</published>
+    <updated>2017-11-08T15:16:06-05:00</updated>
+    <link rel="alternate" type="text/html" href="/livewire/gop-virginia-rep-trump-divisive-rhetoric-prompted-high-dem-turnout"/>
+    <title>GOP Virginia Rep.: Democratic Win In Virginia Was 'Referendum' On Trump</title>
+    <content type="html">&lt;p class="p1"&gt;&lt;span class="s1"&gt;Rep. Scott Taylor (R-VA) said there were plenty of factors that contributed to Democrat Ralph Northam&amp;#8217;s big win in Virginia on Tuesday, but the “overwhelming thing” that pushed Democrats to come out and vote was the “divisive rhetoric” spurred on by President Donald Trump. &lt;/span&gt;&lt;/p&gt;
+&lt;p class="p1"&gt;&lt;span class="s1"&gt;“You have to give credit where credit is due. Democrats showed up last night, there’s no question about it,” he said on CNN’s “New Day” Wednesday morning. “You can attribute some of the things to the candidate, Gillespie, as well too, but there was an overwhelming thing that was looming large and that was the divisive rhetoric.”&lt;/span&gt;&lt;/p&gt;
+&lt;p class="p1"&gt;&lt;span class="s1"&gt;Taylor, who has consistently said he supports Trump, but “not blindly,” said last night’s Democratic wins were “a referendum” on the President. &lt;/span&gt;&lt;/p&gt;
+&lt;p class="p1"&gt;&lt;span class="s1"&gt;“I don’t think there’s any way you can look at it in a different way, to be honest with you, and be intellectually consistent,” he said, adding he doesn’t agree with Trump’s assessment that Republican candidate Ed Gillespie lost because he didn’t fully “embrace” the President. &lt;/span&gt;&lt;/p&gt;
+&lt;p class="p1"&gt;&lt;span class="s1"&gt;“With all due respect to the President, I simply profoundly disagree with that,” he said.&lt;/span&gt;&lt;/p&gt;
+&lt;p class="p1"&gt;&lt;span class="s1"&gt;The &lt;a href="http://talkingpointsmemo.com/dc/democrats-smell-blood-in-the-water-for-2018-after-tuesdays-electoral-romp"&gt;significant Democratic wins&lt;/a&gt; in Virginia and New Jersey, and in other state and local races coast-to-coast Tuesday, had Democrats hopeful for the beginning of a turning point for the party. &lt;/span&gt;&lt;/p&gt;
+&lt;p class="p1"&gt;&lt;span class="s1"&gt;Republicans tried to downplay the results. Speaker of the House Paul Ryan (R-WI) said his party would probably be “saying the same kind of thing” if roles were reversed. &lt;/span&gt;&lt;span class="s1"&gt;“That’s the way the spin works on these things,” &lt;a href="http://talkingpointsmemo.com/livewire/paul-ryan-republicans-already-chose-trump-democrats-election-day-rout"&gt;he said on Fox News’ Brian Kilmeade’s radio show.&lt;/a&gt;&lt;/span&gt;&lt;/p&gt;
+&lt;p&gt;Watch the interview with Taylor below:&lt;br /&gt;
+&lt;iframe src="https://www.youtube.com/embed/q8B4VbZIt40" width="560" height="315" frameborder="0" allowfullscreen="allowfullscreen"&gt;&lt;/iframe&gt;&lt;/p&gt;</content>
+    <author>
+      <name>Nicole Lafond</name>
+    </author>
+  </entry>
+  <entry>
+    <id>tag:talkingpointsmemo.com,2005:ArticleDecorator/270053</id>
+    <published>2017-11-08T14:48:50-05:00</published>
+    <updated>2017-11-08T14:48:50-05:00</updated>
+    <link rel="alternate" type="text/html" href="/livewire/justice-department-cnn-sale-time-warner-att-merger"/>
+    <title>Reports: DOJ Could Seek CNN Sale Before AT&amp;T-Time Warner Merger</title>
+    <content type="html">&lt;p class="p1"&gt;The Department of Justice told AT&amp;amp;T that it would need to sell off CNN or offer other concessions in order to have its acquisition of Time Warner approved, according to several reports Wednesday. The reports differed slightly on the details.&lt;/p&gt;
+&lt;p class="p1"&gt;The &lt;a href="https://www.ft.com/content/149b22dc-c494-11e7-a1d2-6786f39ef675"&gt;Financial Times first reported&lt;/a&gt; the news, citing three unnamed people with direct knowledge of negotiations over the $84.5 billion deal. Its sources said the Justice Department called for the sale of CNN specifically, though it noted that dropping CNN was “&lt;span class="s3"&gt;just one of the demands” the government had made in order to approve the deal. One unnamed source said CNN&amp;#8217;s sale was one of two demands.&lt;/span&gt;&lt;/p&gt;
+&lt;p&gt;President Donald Trump has feuded with CNN since his days as a candidate, calling the network &amp;#8220;fake news.&amp;#8221;&lt;/p&gt;
+&lt;p class="p1"&gt;&lt;a href="https://www.politico.com/story/2017/11/08/att-time-warner-dump-cnn-244697"&gt;Politico&lt;/a&gt; followed up on the FT report, though its unnamed sources “familiar with the discussions” said only that the DOJ’s expectations of &lt;span class="s1"&gt;&amp;#8220;structural remedies&amp;#8221; were being interpreted as an ultimatum to sell off CNN. &lt;/span&gt;&lt;/p&gt;
+&lt;p class="p5"&gt;The &lt;a href="https://www.nytimes.com/2017/11/08/business/dealbook/att-time-warner.html"&gt;New York Times&lt;/a&gt;, citing unnamed people “briefed on the matter,” said that AT&amp;amp;T and Time Warner had been told to sell off Turner Broadcasting, of which CNN is one of several cable channels. Two unnamed sources told the paper that the deal could alternatively go forward if AT&amp;amp;T sold DirecTV, the satellite TV provider it bought in 2015.&lt;/p&gt;
+&lt;p&gt;On Wednesday, responding to a reported Justice Department claim that he had offered to sell CNN, &lt;span class="s2"&gt;AT&amp;amp;T’s CEO, Randall &lt;/span&gt;Stephenson, refuted the claim and said &amp;#8220;throughout this process, I have never offered to sell CNN and have no intention of doing so,&amp;#8221; according to CNN&amp;#8217;s Brian Stelter and Politico&amp;#8217;s Michael Calderone.&lt;/p&gt;
+&lt;blockquote class="twitter-tweet" data-width="550"&gt;
+&lt;p lang="en" dir="ltr"&gt;NEW: The Justice Dept claims that AT&amp;amp;T privately offered to sell CNN. AT&amp;amp;T CEO Randall Stephenson DENIES that: &amp;quot;Throughout this process, I have never offered to sell CNN and have no intention of doing so.&amp;quot;&lt;/p&gt;
+&lt;p&gt;&amp;mdash; Brian Stelter (@brianstelter) &lt;a href="https://twitter.com/brianstelter/status/928361984038281216?ref_src=twsrc%5Etfw"&gt;November 8, 2017&lt;/a&gt;&lt;/p&gt;&lt;/blockquote&gt;
+&lt;p&gt;&lt;script async src="https://platform.twitter.com/widgets.js" charset="utf-8"&gt;&lt;/script&gt;&lt;/p&gt;
+&lt;blockquote class="twitter-tweet" data-width="550"&gt;
+&lt;p lang="en" dir="ltr"&gt;AT&amp;amp;T CEO Randall Stephenson says he has “never offered to sell CNN and have no intention of doing so.&amp;quot; &lt;a href="https://t.co/NpuP9pHEIt"&gt;pic.twitter.com/NpuP9pHEIt&lt;/a&gt;&lt;/p&gt;
+&lt;p&gt;&amp;mdash; Michael Calderone (@mlcalderone) &lt;a href="https://twitter.com/mlcalderone/status/928363527131357185?ref_src=twsrc%5Etfw"&gt;November 8, 2017&lt;/a&gt;&lt;/p&gt;&lt;/blockquote&gt;
+&lt;p&gt;&lt;script async src="https://platform.twitter.com/widgets.js" charset="utf-8"&gt;&lt;/script&gt;&lt;/p&gt;
+&lt;p class="p1"&gt;&lt;span class="s1"&gt;“We are in active discussions with the D.O.J.,” AT&amp;amp;T CFO John Stephens told the New York Times earlier Tuesday. “I cannot comment on those discussions. But with those discussions, I can now say that the timing of the closing of the deal is now uncertain.”&lt;/span&gt;&lt;/p&gt;
+&lt;p class="p5"&gt;In October 2016, AT&amp;amp;T and Time Warner said they had reached a merger deal, marking an especially massive consolidation in a media industry now used to them.&lt;/p&gt;
+&lt;p class="p5"&gt;&amp;#8220;We think AT&amp;amp;T has tremendous capabilities that we don’t have on our own,” Time Warner’s CEO said at the time, &lt;a href="http://www.latimes.com/entertainment/envelope/cotown/la-et-ct-att-time-warner-deal-20161022-snap-story.html"&gt;according to the Los Angeles Times&lt;/a&gt;. He cited AT&amp;amp;T&amp;#8217;s mobile device-driven potential to deliver Time Warner content to its customers. “This is a unique combination.”&lt;/p&gt;
+&lt;p class="p5"&gt;Still, the deal needs the Justice Department’s approval.&lt;/p&gt;
+&lt;p class="p8"&gt;&lt;span class="s2"&gt;“It’s all about CNN,” one unnamed source with “direct knowledge” of the negotiations told the Financial Times.&lt;/span&gt;&lt;/p&gt;
+&lt;p class="p8"&gt;&lt;span class="s2"&gt;During the 2016 presidential campaign, Donald Trump, who as President has been &lt;a href="https://www.realclearpolitics.com/video/2017/11/03/trump_a_lot_of_people_are_disappointed_in_justice_department_including_me.html"&gt;known to violate traditional barriers&lt;/a&gt; between his administration and the Department of Justice, said he was against the merger.&lt;/span&gt;&lt;/p&gt;
+&lt;p class="p8"&gt;&lt;span class="s2"&gt;He said his administration “&lt;a href="https://www.wsj.com/articles/trump-says-he-would-block-at-t-time-warner-deal-1477162214"&gt;will not approve&lt;/a&gt;” the deal “because it’s too much concentration of power in the hands of too few.”&lt;/span&gt; White House adviser Kellyanne Conway denied on Sunday that the White House was intervening in the Justice Department&amp;#8217;s work on the deal, Politico noted.&lt;/p&gt;
+&lt;p class="p8"&gt;&lt;span class="s2"&gt;Stephenson &lt;a href="http://www.businessinsider.com/att-ceo-time-warner-does-not-need-to-spin-off-cnn-2017-1"&gt;has said&lt;/a&gt; in the past that selling off CNN “&lt;/span&gt;&lt;span class="s5"&gt;doesn&amp;#8217;t seem relevant to approving a deal like this.&amp;#8221; &lt;/span&gt;&lt;span class="s2"&gt;Last week, the Wall Street Journal &lt;a href="https://www.wsj.com/articles/u-s-weighs-suit-against-at-ts-deal-for-time-warner-1509633797?tesla=y&amp;amp;mod=e2tw"&gt;reported&lt;/a&gt; that Trump’s Justice Department was weighing a lawsuit challenging the deal.&lt;/span&gt;&lt;/p&gt;
+&lt;p&gt;&lt;em&gt;This post has been updated.&lt;/em&gt;&lt;/p&gt;</content>
+    <author>
+      <name>Matt Shuham</name>
+    </author>
+  </entry>
+  <entry>
+    <id>tag:talkingpointsmemo.com,2005:ArticleDecorator/270052</id>
+    <published>2017-11-08T14:23:48-05:00</published>
+    <updated>2017-11-08T14:23:48-05:00</updated>
+    <link rel="alternate" type="text/html" href="/livewire/bill-o-reilly-contract-harassment-allegations"/>
+    <title>Doc: O'Reilly Contract Barred Fox From Firing Him Unless Claims Proven In Court</title>
+    <content type="html">&lt;p&gt;Although several women had accused then-Fox News host Bill O&amp;#8217;Reilly of sexual harassment, forcing him to pay out large settlements to his accusers, Fox News stood by O&amp;#8217;Reilly, one of the network&amp;#8217;s most prominent figures, until April of this year.&lt;/p&gt;
+&lt;p&gt;A document published by the British government on Wednesday revealed that O&amp;#8217;Reilly&amp;#8217;s contract with Fox News barred the network from firing O&amp;#8217;Reilly over sexual harassment accusations unless the allegations were proven in court. Fox News had to stand by O&amp;#8217;Reilly for the remainder of his contract unless one of his accusers won in court.&lt;/p&gt;
+&lt;p&gt;Jacques Nasser, an independent director on the board of 21st Century Fox, told the United Kingdom&amp;#8217;s Competition and Markets Authority about the contract provision, according to a &lt;a href="https://assets.publishing.service.gov.uk/media/5a02f9ebe5274a0ee28af81d/summary-of-hearing-with-jacques-nasser.pdf"&gt;summary of his remarks&lt;/a&gt; at an October hearing published by the authority.&lt;/p&gt;
+&lt;p&gt;The Competition and Markets Authority is reviewing 21st Century Fox&amp;#8217;s bid to acquire British news outlet Sky News. Fox has seen scrutiny from British regulators over the way the company handled sexual harassment claims against former Fox News CEO Roger Ailes and O&amp;#8217;Reilly.&lt;/p&gt;
+&lt;p&gt;Nasser said that 21st Century Fox&amp;#8217;s board was aware of the settlements O&amp;#8217;Reilly paid to his accusers, though not the specific sums, and that the board did not act on the allegations against O&amp;#8217;Reilly in part due to the contract provision. Nasser said that some board members wanted to fire O&amp;#8217;Reilly immediately, while others wanted to wait for his contract renewal. Ultimately, the board made sure that when O&amp;#8217;Reilly&amp;#8217;s contract was renewed, it did not include a clause barring the company from firing him over allegations, Nasser said.&lt;/p&gt;
+&lt;p&gt;A few months later, O&amp;#8217;Reilly left the network. He was ousted from Fox News after the New York Times &lt;a href="https://www.nytimes.com/2017/04/01/business/media/bill-oreilly-sexual-harassment-fox-news.html?_r=2"&gt;revealed&lt;/a&gt; in April that O&amp;#8217;Reilly or the company had paid settlements to five women who accused him of sexual harassment. The Times then &lt;a href="http://talkingpointsmemo.com/livewire/nyt-reports-o-reilly-settlement-harassment-allegations"&gt;reported&lt;/a&gt; in October that O&amp;#8217;Reilly had paid a $32 million settlement to a former Fox News analyst who accused O&amp;#8217;Reilly of sexual misconduct in January, only about a month before Fox renewed his contract.&lt;/p&gt;
+&lt;p&gt;The Competition and Markets Authority is reviewing the possible merger following a review from the UK&amp;#8217;s communications regulator, Ofcom. In an August letter, Ofcom &lt;a href="http://talkingpointsmemo.com/livewire/uk-probe-likely-fox-sky-news"&gt;wrote&lt;/a&gt; that its review of Fox found &amp;#8220;significant corporate failures&amp;#8221; when it came to &amp;#8220;alleged behaviors.&amp;#8221; The letter did not specify the allegations, but it&amp;#8217;s possible Ofcom was referring to the way Fox handled sexual harassment allegations.&lt;/p&gt;
+&lt;p&gt;H/t &lt;a href="https://www.bloomberg.com/news/articles/2017-11-08/o-reilly-s-fox-deal-shielded-him-from-firing-over-allegations"&gt;Bloomberg News&lt;/a&gt;&lt;/p&gt;</content>
+    <author>
+      <name>Caitlin MacNeal</name>
+    </author>
+  </entry>
+  <entry>
+    <id>tag:talkingpointsmemo.com,2005:ArticleDecorator/270051</id>
+    <published>2017-11-08T14:17:20-05:00</published>
+    <updated>2017-11-08T14:17:20-05:00</updated>
+    <link rel="alternate" type="text/html" href="/edblog/boom-watch-this-closely"/>
+    <title>Boom - Watch This Closely</title>
+    <content type="html">&lt;p&gt;I&amp;#8217;ve &lt;a href="http://talkingpointsmemo.com/edblog/will-it-soon-be-cnns-time-in-the-barrel"&gt;previously noted the chatter that&lt;/a&gt; AT&amp;amp;T may have or may need to give President Trump assurances that CNN will be reined in before his Justice Department okays its $84.5 billion acquisition of Time Warner. &lt;em&gt;The Financial Times&lt;/em&gt; has &lt;a href="https://www.ft.com/content/149b22dc-c494-11e7-a1d2-6786f39ef675"&gt;just reported&lt;/a&gt; (sub req) that the DOJ is now telling AT&amp;amp;T that it needs to sell CNN if it wants the acquisition approved.
+
+&lt;/p&gt;
+&lt;p&gt;From the &lt;em&gt;FT&lt;/em&gt; &amp;#8230;&lt;/p&gt;
+&lt;blockquote&gt;&lt;p&gt;The sale of CNN, which President Donald Trump has fiercely criticised as a broadcaster of “fake news”, is just one of the demands being made by the US antitrust authority in order to sign off on the deal, those involved in the talks said. But it could prove a stumbling block.&lt;/p&gt;
+&lt;p&gt;AT&amp;amp;T is opposed to selling the TV network and is preparing to take the Trump administration to court, arguing the deal with Time Warner does not pose any competition violations.&lt;/p&gt;
+&lt;p&gt;“It’s all about CNN,” said one person with direct knowledge of the talks between the company and the DOJ, adding that the regulator made it clear to AT&amp;amp;T that if it sold CNN the deal would go through.&lt;/p&gt;&lt;/blockquote&gt;
+&lt;p&gt;Makan Delrahim is the new head of the AntiTrust division &amp;#8230;&lt;/p&gt;
+&lt;blockquote&gt;&lt;p&gt;Makan Delrahim, the new head of the justice department’s antitrust division, has been more conciliatory, saying before taking office that he did not believe the merger posed a “major antitrust problem”.&lt;/p&gt;
+&lt;p&gt;“The sheer size of it, and the fact that it’s media, I think will get a lot of attention,” Mr Delrahim told a Canadian TV station in 2016 after the AT&amp;amp;T deal with Time Warner was announced. “However, I don’t see this as a major antitrust problem.”&lt;/p&gt;
+&lt;p&gt;People with direct knowledge of the antitrust negotiations said Mr Delrahim had changed his view since taking office.&lt;/p&gt;&lt;/blockquote&gt;
+&lt;p&gt;As I&amp;#8217;ve noted in other contexts, I believe that as a general matter antitrust enforcement should be much more expansive and aggressive than it&amp;#8217;s been in recent decades. But that&amp;#8217;s a separate point. The key here is selective enforcement to advance political ends. We don&amp;#8217;t know that that is what&amp;#8217;s happening here. But given the players involved we have good reason to be highly suspicious.&lt;/p&gt;</content>
+    <author>
+      <name>Josh Marshall</name>
+    </author>
+  </entry>
+  <entry>
+    <id>tag:talkingpointsmemo.com,2005:ArticleDecorator/270050</id>
+    <published>2017-11-08T13:56:21-05:00</published>
+    <updated>2017-11-08T13:56:21-05:00</updated>
+    <link rel="alternate" type="text/html" href="/livewire/rnc-chair-challenges-trump-claims-gillespie-didnt-embrace"/>
+    <title>RNC Chair Challenges Trump’s Claims That Gillespie Didn’t ‘Embrace Me’</title>
+    <content type="html">&lt;p class="p1"&gt;&lt;span class="s1"&gt;President Donald Trump was &lt;a href="http://talkingpointsmemo.com/livewire/trump-gillespie-did-not-embrace-me"&gt;quick to distance himself&lt;/a&gt; from the Virginia gubernatorial candidate he endorsed following Republican Ed Gillespie’s defeat Tuesday evening. Trump tweeted from South Korea that the candidate “worked hard, but did not embrace me.”&lt;/span&gt;&lt;/p&gt;
+&lt;p class="p1"&gt;&lt;span class="s1"&gt;But Republican National Committee chair Ronna Romney McDaniel pushed back on that claim. &lt;/span&gt;&lt;/p&gt;
+&lt;p class="p1"&gt;&lt;span class="s1"&gt;“Ed did work with the President, he did robocalls and he had tweets,” she said, likely referencing a robocall Trump made prior to Election Day encouraging voters that Gillespie “will help make America great again.”&lt;/span&gt;&lt;/p&gt;
+&lt;p class="p1"&gt;&lt;span class="s1"&gt;It appears Trump did more to embrace Gillespie, than vice versa. The President tweeted support for Gillespie in late October and&lt;a href="http://talkingpointsmemo.com/livewire/trump-virtually-campaigns-gillespie-south-korea"&gt; again on Tuesday&lt;/a&gt;. Gillespie failed to mention the Presidential tweets of support at later campaign events. Gillespie even &lt;a href="http://talkingpointsmemo.com/dc/as-trump-tweets-about-gillespie-he-ducks-any-mention-of-president-on-trail"&gt;dodged questions from TPM&lt;/a&gt; about Trump at a campaign event. &lt;/span&gt;&lt;/p&gt;
+&lt;p class="p1"&gt;&lt;span class="s1"&gt;McDaniel went on to contradict herself, saying the reason Virginia Gov.-elect Ralph Northam (D) won was because he said he would be willing to work with the President if it helped the people of Virginia. &lt;/span&gt;&lt;/p&gt;
+&lt;p class="p1"&gt;&lt;span class="s1"&gt;“Our base is for our President. The enthusiasm for the President is still strong. … Voters want to see candidates embrace the President,” she said. “If there’s a playbook for Democrats, they should work with the President. … I absolutely think any candidate should be embracing the President and I think Ed did.” &lt;/span&gt;&lt;/p&gt;</content>
+    <author>
+      <name>Nicole Lafond</name>
+    </author>
+  </entry>
+  <entry>
+    <id>tag:talkingpointsmemo.com,2005:ArticleDecorator/270049</id>
+    <published>2017-11-08T13:52:05-05:00</published>
+    <updated>2017-11-08T13:52:05-05:00</updated>
+    <link rel="alternate" type="text/html" href="/edblog/whose-team-is-he-on"/>
+    <title>Whose Team Is He On?</title>
+    <content type="html">&lt;p&gt;I &lt;a href="https://talkingpointsmemo.com/prime-beta/trump-cant-cross-putin"&gt;noted yesterday&lt;/a&gt; (sub req) that I think that even if Trump had or has come to hate Russia and Vladimir Putin he must know he can&amp;#8217;t cross them now because of the compromising information they could easily use against him.&lt;/p&gt;
+&lt;p&gt;Here&amp;#8217;s something else that needs to be flagged.
+
+&lt;/p&gt;
+&lt;p&gt;Yesterday news broke that President Trump had &lt;a href="http://talkingpointsmemo.com/muckraker/binney-pompeo-seth-rich"&gt;insisted his CIA Director Mike Pompeo meet with&lt;/a&gt; a former US intelligence analyst turned conspiracy theorist who says his independent analysis shows that the entirety of Russian interference in the 2016 election is a hoax. The hacking of the DNC was actually an inside job.&lt;/p&gt;
+&lt;p&gt;I follow Russian diplomatic Twitter and this morning I saw this. Lavrov is Russia&amp;#8217;s longtime foreign minister. He&amp;#8217;s the guy who met President Trump in the Oval Office earlier this year.&lt;/p&gt;
+&lt;blockquote class="twitter-tweet" data-lang="en"&gt;
+&lt;p dir="ltr" lang="en"&gt;FM Lavrov: all established facts point not to a “Russian trace” in 2016 US election, but rather to &lt;a href="https://twitter.com/TheDemocrats?ref_src=twsrc%5Etfw"&gt;@TheDemocrats&lt;/a&gt; inside job &lt;a href="https://t.co/E507uaQ1kx"&gt;pic.twitter.com/E507uaQ1kx&lt;/a&gt;&lt;/p&gt;
+&lt;p&gt;— Russian Embassy, UK (@RussianEmbassy) &lt;a href="https://twitter.com/RussianEmbassy/status/928264092703326210?ref_src=twsrc%5Etfw"&gt;November 8, 2017&lt;/a&gt;&lt;/p&gt;&lt;/blockquote&gt;
+&lt;p&gt;&lt;script async src="https://platform.twitter.com/widgets.js" charset="utf-8"&gt;&lt;/script&gt;&lt;/p&gt;
+&lt;p&gt;In Trump&amp;#8217;s semi-defense, this isn&amp;#8217;t the only place you can hear this idea. The guy Trump made Pompeo meet with, Bill Binney, has frequently appeared on Fox News. But Russian bots and the Russian Foreign Minister is actively pushing precisely the same theory of what happened last year.&lt;/p&gt;
+&lt;p&gt;These actions aren&amp;#8217;t inconsequential or merely retrospective. Russian efforts to tamper in US elections and sow division in American society continue apace. Repeatedly insisting to the people charged with preventing further intrusions that the first intrusion never happened can only be viewed as active complicity in future attacks. Sound alarmist? Sure. But think about it. If you keep telling the security guard that the break in the night before never happened and that they should just go home, what would you call that? Why he is doing this I can&amp;#8217;t say. But what he is doing is demonstrably and on its face active assistance of future attacks. There&amp;#8217;s no other way to put it.&lt;/p&gt;</content>
+    <author>
+      <name>Josh Marshall</name>
+    </author>
+  </entry>
+  <entry>
+    <id>tag:talkingpointsmemo.com,2005:ArticleDecorator/270048</id>
+    <published>2017-11-08T13:40:42-05:00</published>
+    <updated>2017-11-08T13:40:42-05:00</updated>
+    <link rel="alternate" type="text/html" href="/news/menendez-trial-enters-second-day-deliberations"/>
+    <title>Menendez Trial Enters Second Full Day Of Jury Deliberations</title>
+    <content type="html">&lt;p&gt;NEWARK, N.J. (AP) — The second full day of jury deliberations has begun in the bribery trial of Sen. Bob Menendez.&lt;/p&gt;
+&lt;p&gt;The New Jersey Democrat is charged with accepting gifts from a wealthy friend in exchange for using his political influence.&lt;/p&gt;
+&lt;p&gt;The balance of the Senate could be affected if Menendez is convicted and then voted out by a two-thirds majority.&lt;/p&gt;
+&lt;p&gt;Though Democrat Phil Murphy was elected New Jersey governor Tuesday, incumbent Republican Chris Christie can name a replacement until he leaves office in January.&lt;/p&gt;
+&lt;p&gt;If jurors don&amp;#8217;t reach a verdict by Thursday evening, the judge says he&amp;#8217;ll excuse a juror who has a scheduled vacation beginning Monday and replace her with an alternate. The panel would then start over.&lt;/p&gt;</content>
+    <author>
+      <name>Associated Press</name>
+    </author>
+  </entry>
+  <entry>
+    <id>tag:talkingpointsmemo.com,2005:ArticleDecorator/270047</id>
+    <published>2017-11-08T12:51:57-05:00</published>
+    <updated>2017-11-08T12:51:57-05:00</updated>
+    <link rel="alternate" type="text/html" href="/news/obama-reports-for-jury-duty-chicago"/>
+    <title>Obama Reports For Jury Duty In Chicago, Ends Up Being Dismissed</title>
+    <content type="html">&lt;p&gt;CHICAGO (AP) — Former President Barack Obama, free of a job that forced him to move to Washington for eight years, showed up to a downtown Chicago courthouse for jury duty on Wednesday morning. Then he heard the words most prospective jurors pray for: You&amp;#8217;re dismissed.&lt;/p&gt;
+&lt;p&gt;The 44th president&amp;#8217;s motorcade — considerably shorter than the one when he lived in the White House — left his home in the Kenwood neighborhood on the city&amp;#8217;s South Side and arrived at the Richard J. Daley Center shortly after 10 a.m.&lt;/p&gt;
+&lt;p&gt;Obama — wearing a dark sport coat, dress shirt, but without a tie — waved to people who gathered outside.&lt;/p&gt;
+&lt;p&gt;Shortly before noon, Cook County Chief Judge Timothy Evans told reporters that the former president had not been selected for jury duty. But Obama was ready to serve if told to do so, Evans said.&lt;/p&gt;
+&lt;p&gt;In fact, Obama was also summoned in 2010 but that was during his most powerful leader in the world period, and he was able to postpone reporting, according to his spokeswoman, Katie Hill.&lt;/p&gt;
+&lt;p&gt;On Wednesday, Obama did get the prospective juror experience of sitting through a decades-old, 20-minute video in which Lester Holt— now the anchor of NBC Nightly News but back then on local news —explained the ins-and-outs of jury duty.&lt;/p&gt;
+&lt;p&gt;Obama&amp;#8217;s experience was a bit different than the others who watched the video. When he arrived there was a feeding frenzy as crowds of people inside the courthouse took photos and videos of the former president. As happens most days, would-be jurors brought books, but on Wednesday some people brought books Obama had authored in hopes he might sign them. He obliged them and posed for photographs, Evans said.&lt;/p&gt;
+&lt;p&gt;&amp;#8220;Look at this. Did you know I was coming?&amp;#8221; he asked one man who held a copy of Obama&amp;#8217;s &amp;#8220;Dreams From My Father.&amp;#8221;&lt;/p&gt;
+&lt;p&gt;Thomas Pearson, who took the video and called the experience of shaking hands with Obama &amp;#8220;the best thing I experienced in my entire life,&amp;#8221; said he wasn&amp;#8217;t going to show up for jury duty until his mother texted him that Obama would be there.&lt;/p&gt;
+&lt;p&gt;For his troubles, Obama is in line to receive $17.20 — the daily rate of pay for performing this civic duty. Hill said that the former president would donate it to Cook County.&lt;/p&gt;
+&lt;p&gt;Obama is the highest-ranking former public official to be called to jury duty in Chicago. But he is not the first former president to be called to jury duty. In 2015, former President George W. Bush answered the jury duty call in Dallas. He was not selected to sit on a jury. And in 2003, former President Bill Clinton reported for jury duty in federal court in New York City. He also was not selected.&lt;/p&gt;
+&lt;p&gt;Nor is Obama the first famous Chicago resident to be called to jury duty. In 2004, Oprah Winfrey was on a Chicago jury that convicted a man of murder. A decade later, Lawrence Tureaud, better known as Mr. T, showed up to a suburban Chicago courthouse for jury duty, sporting his usual Mohawk, but without the gold chains for which he is known. Mr. T was not chosen to sit on a jury.&lt;/p&gt;</content>
+    <author>
+      <name>DON BABWIN</name>
+    </author>
+  </entry>
+  <entry>
+    <id>tag:talkingpointsmemo.com,2005:ArticleDecorator/270046</id>
+    <published>2017-11-08T12:50:55-05:00</published>
+    <updated>2017-11-08T12:50:55-05:00</updated>
+    <link rel="alternate" type="text/html" href="/livewire/pelosi-schumer-republicans-better-look-out-election-results"/>
+    <title>Top Dems Say Election Day Rout Is 2018 Bellwether: The GOP 'Better Look Out'</title>
+    <content type="html">&lt;p&gt;Top congressional Democrats on Wednesday said the party&amp;#8217;s coast-to-coast victories on Election Day show that the &amp;#8220;door is certainly open&amp;#8221; for a similar triumph in the 2018 midterm elections.&lt;/p&gt;
+&lt;p&gt;&amp;#8220;The door is certainly open for us,&amp;#8221; House Minority Leader Nancy Pelosi (D-CA) told reporters.&lt;/p&gt;
+&lt;p&gt;She compared President Donald Trump&amp;#8217;s present approval ratings to former President George W. Bush&amp;#8217;s job approval in 2005.&lt;/p&gt;
+&lt;p&gt;&amp;#8220;In &amp;#8217;05, right now, we have President Bush down to 38 percent,&amp;#8221; Pelosi said. &amp;#8220;That&amp;#8217;s approximately where President Trump is now. That opens the door. That means we get the fresh recruits and they get the retirements.&amp;#8221;&lt;/p&gt;
+&lt;p&gt;Democratic candidates won the House, the Senate and a majority of state-level races in 2006, when Pelosi was nominated as her party&amp;#8217;s candidate for House speaker.&lt;/p&gt;
+&lt;p&gt;Senate Minority Leader Chuck Schumer (D-NY) said Tuesday&amp;#8217;s results should worry elected Republicans.&lt;/p&gt;
+&lt;p&gt;&amp;#8220;In 2005, I was head of the DSCC,&amp;#8221; he said, referring to the Democratic Senatorial Campaign Committee. &amp;#8220;And you could smell a wave coming. The results last night smell exactly the same way. Our Republican friends better look out.&amp;#8221;&lt;/p&gt;</content>
+    <author>
+      <name>Esme Cribb</name>
+    </author>
+  </entry>
+  <entry>
+    <id>tag:talkingpointsmemo.com,2005:ArticleDecorator/270045</id>
+    <published>2017-11-08T12:08:23-05:00</published>
+    <updated>2017-11-08T12:08:23-05:00</updated>
+    <link rel="alternate" type="text/html" href="/muckraker/judge-issues-gag-order-manafort-gates-case"/>
+    <title>Judge Slaps Gag Order On Everyone Involved In Manafort-Gates Case</title>
+    <content type="html">&lt;p&gt;The federal judge overseeing the financial crimes case against former Trump campaign officials Paul Manafort and Rick Gates on Wednesday issued a gag order preventing everyone involved or potentially involved from talking to the press.&lt;/p&gt;
+&lt;p&gt;“The parties, any potential witnesses, and counsel for the parties and the witnesses, are hereby ORDERED to refrain from making statements to the media or in public settings that pose a substantial likelihood of material prejudice to this case,” U.S. District Judge Amy Berman Jackson said in her order.&lt;/p&gt;
+&lt;p&gt;Jackson said it was intended to ensure the defendants’ right to a fair trial and that selected jurors are not “tainted by pretrial publicity.”&lt;/p&gt;
+&lt;p&gt;As part of his broader probe of Russian meddling in the 2016 election, and possible collusion by Americans, Special Counsel Robert Mueller obtained a grand jury indictment against Manafort and Gates for alleged money laundering, tax evasion and failing to disclose lobbying activities for foreign politicians.&lt;/p&gt;
+&lt;p&gt;At a hearing last Thursday, Jackson &lt;a href="http://talkingpointsmemo.com/muckraker/manafort-house-arrest-mueller-judge"&gt;clearly signaled her disapproval&lt;/a&gt; of grandstanding by the attorneys in the case, warning them against making their arguments “on the courthouse steps” and giving them until Wednesday to file motions opposing the gag order. No parties involved in the case did so.&lt;/p&gt;
+&lt;p&gt;Even before the order was issued, Jackson’s initial warning seemed to deter attorneys from speaking out. Manafort’s lawyer, Kevin Downing, told reporters that the case was “ridiculous” after his client’s initial appearance in front of a magistrate judge on Monday. After the Thursday hearing, he and Manafort departed in silence.&lt;/p&gt;
+&lt;p&gt;&lt;iframe src="https://drive.google.com/file/d/1uNbTC2waMq8inwFFouzk0EzqnC6OJG_U/preview" width="640" height="480"&gt;&lt;/iframe&gt;&lt;/p&gt;</content>
+    <author>
+      <name>Allegra Kirkland</name>
+    </author>
+  </entry>
+  <entry>
+    <id>tag:talkingpointsmemo.com,2005:ArticleDecorator/270044</id>
+    <published>2017-11-08T11:59:28-05:00</published>
+    <updated>2017-11-08T11:59:28-05:00</updated>
+    <link rel="alternate" type="text/html" href="/dc/tuesday-election-firsts-for-women-transgender-people-minorities"/>
+    <title>A Night Of Firsts: Range Of Diverse Dems Elected To Public Office</title>
+    <content type="html">&lt;p&gt;Diverse Democratic candidates scored wins on Tuesday night in cities and states across the country, with female, transgender, and minority candidates making history by winning public office.&lt;/p&gt;
+&lt;p&gt;Take a look at some of the Democrats who made history Tuesday night with their election victories:&lt;/p&gt;
+&lt;h2&gt;Danica Roem&lt;/h2&gt;
+&lt;p&gt;Democrat Danica Roem (pictured above) became one of the first openly transgender women to win public office when she &lt;a href="https://www.washingtonpost.com/local/virginia-politics/danica-roem-will-be-vas-first-openly-transgender-elected-official-after-unseating-conservative-robert-g-marshall-in-house-race/2017/11/07/d534bdde-c0af-11e7-959c-fe2b598d8c00_story.html?tid=a_inl&amp;amp;utm_term=.4ff7ce20b750"&gt;unseated&lt;/a&gt; incumbent Virginia Republican state Del. Robert Marshall, who drafted a &amp;#8220;bathroom bill&amp;#8221; in the state.&lt;/p&gt;
+&lt;p&gt;Roem will be the first person to campaign as an openly transgender person to take a seat in a statehouse. Stacie Laughton was the first openly transgender woman to win a seat on a state legislature in a 2012 New Hampshire race, but she never took office. Althea Garrison, a transgender woman served a term in the Massachusetts state legislature but did not run as an openly transgender person.&lt;/p&gt;
+&lt;p&gt;“To every person who has ever been singled out, who has ever been stigmatized, who has ever been the misfit, who has ever been the kid in the corner, who has ever needed someone to stand up for them when they didn’t have a voice of their own,&amp;#8221; &lt;a href="https://www.nbcnews.com/feature/nbc-out/democrat-danica-roem-transgender-woman-elected-virginia-state-legislature-n818876"&gt;Roem told supporters Tuesday night&lt;/a&gt;. &amp;#8220;This is for you.”&lt;/p&gt;
+&lt;h2&gt;Joyce Craig&lt;/h2&gt;
+&lt;p&gt;&amp;nbsp;&lt;/p&gt;
+&lt;p&gt;&lt;img class="aligncenter size-large wp-image-1094520" src="https://dawm7kda6y2v0.cloudfront.net/uploads/2017/11/joyce-craig-804x518-c5107ef.jpg" alt="" width="804" height="518" srcset="https://dawm7kda6y2v0.cloudfront.net/uploads/2017/11/joyce-craig-804x518-c5107ef.jpg 804w, https://dawm7kda6y2v0.cloudfront.net/uploads/2017/11/joyce-craig-600x387-f824764.jpg 600w, https://dawm7kda6y2v0.cloudfront.net/uploads/2017/11/joyce-craig-98x64-4a9b479.jpg 98w, https://dawm7kda6y2v0.cloudfront.net/uploads/2017/11/joyce-craig.jpg 827w, https://dawm7kda6y2v0.cloudfront.net/uploads/2017/11/joyce-craig-98x64-4a9b479@2x.jpg 196w" sizes="(max-width: 804px) 100vw, 804px" /&gt;&lt;/p&gt;
+&lt;p&gt;Democrat Joyce Craig became the first female mayor of Manchester, the largest city in New Hampshire, when she defeated incumbent Mayor Ted Gatsas. Manchester saw its largest election turnout this decade, helping propel Craig to victory, according the &lt;a href="http://www.unionleader.com/Manchester-elects-its-first-female-mayor"&gt;Union Leader&lt;/a&gt;.&lt;/p&gt;
+&lt;h2&gt;Vi Lyles&lt;/h2&gt;
+&lt;p&gt;Charlotte, North Carolina elected Vi Lyles mayor on Tuesday, making her the first female African-American mayor of the city. The Democrat defeated Republican Kenny Smith by more than 15 points, according to unofficial returns.&lt;/p&gt;
+&lt;p&gt;“With this opportunity you’ve given me, you’ve proven that we are a city of opportunity and inclusiveness,” Lyles said Tuesday night, according to the &lt;a href="http://www.charlotteobserver.com/news/politics-government/election/article183325696.html"&gt;Charlotte Observer&lt;/a&gt;. “You’ve proven that a woman whose father didn’t graduate from high school can become this city’s first female African-American mayor.”&lt;/p&gt;
+&lt;h2&gt;Andrea Jenkins&lt;/h2&gt;
+&lt;figure id="attachment_1094502" style="width: 804px" class="wp-caption aligncenter"&gt;&lt;img class="size-large wp-image-1094502" src="https://dawm7kda6y2v0.cloudfront.net/uploads/2017/11/andrea-jenkins-804x425-6d7b8fa.jpg" alt="Deebaa Sirdar (left) and Sara Lopez (right) took a selfie with Andrea Jenkins. Jenkins, is the first transgender woman of color elected to public office. ] CARLOS GONZALEZ • cgonzalez@startribune.com - November 2, 2017, Minneapolis, MN - Third Ward city council race -" width="804" height="425" srcset="https://dawm7kda6y2v0.cloudfront.net/uploads/2017/11/andrea-jenkins-804x425-6d7b8fa.jpg 804w, https://dawm7kda6y2v0.cloudfront.net/uploads/2017/11/andrea-jenkins-600x317-e4063b3.jpg 600w, https://dawm7kda6y2v0.cloudfront.net/uploads/2017/11/andrea-jenkins-1000x528-c17af99.jpg 1000w, https://dawm7kda6y2v0.cloudfront.net/uploads/2017/11/andrea-jenkins-804x425-6d7b8fa@2x.jpg 1608w, https://dawm7kda6y2v0.cloudfront.net/uploads/2017/11/andrea-jenkins-600x317-e4063b3@2x.jpg 1200w, https://dawm7kda6y2v0.cloudfront.net/uploads/2017/11/andrea-jenkins-1000x528-c17af99@2x.jpg 2000w" sizes="(max-width: 804px) 100vw, 804px" /&gt;&lt;figcaption class="wp-caption-text"&gt;&lt;em&gt;Deebaa Sirdar (left) and Sara Lopez (right) took a selfie with Andrea Jenkins. Jenkins, is the first transgender woman of color elected to public office. CARLOS GONZALEZ • cgonzalez@startribune.com&lt;/em&gt;&lt;/figcaption&gt;&lt;/figure&gt;
+&lt;p&gt;Andrea Jenkins &lt;a href="https://www.washingtonpost.com/news/the-fix/wp/2017/11/08/meet-andrea-jenkins-the-openly-transgender-black-woman-elected-to-public-office-in-the-u-s/?utm_term=.81720630ef3b"&gt;became&lt;/a&gt; the first openly transgender black woman to win public office on Tuesday when she won a seat on the Minneapolis City Council.&lt;/p&gt;
+&lt;h2&gt;Jenny Durkan&lt;/h2&gt;
+&lt;p&gt;Seattle voters on Tuesday night &lt;a href="https://www.washingtonblade.com/2017/11/08/lesbian-candidate-wins-election-to-become-seattle-mayor/"&gt;elected&lt;/a&gt; the city&amp;#8217;s first openly lesbian woman to be the city&amp;#8217;s mayor, Jenny Durkan. The Democrat is also the first woman to serve as Seattle mayor since 1926.&lt;/p&gt;
+&lt;h2&gt;Justin Fairfax&lt;/h2&gt;
+&lt;figure id="attachment_1094505" style="width: 804px" class="wp-caption aligncenter"&gt;&lt;img class="size-large wp-image-1094505" src="https://dawm7kda6y2v0.cloudfront.net/uploads/2017/11/justin-fairfax-804x536-2f77c5f.jpg" alt="Democrat Lt. Gov.-elect Justine Fairfax addresses the Ralph Northam For Governor election night party at George Mason University in Fairfax, Va., Tuesday, Nov. 7, 2017. (AP Photo/Cliff Owen)" width="804" height="536" srcset="https://dawm7kda6y2v0.cloudfront.net/uploads/2017/11/justin-fairfax-804x536-2f77c5f.jpg 804w, https://dawm7kda6y2v0.cloudfront.net/uploads/2017/11/justin-fairfax-600x400-774f3ae.jpg 600w, https://dawm7kda6y2v0.cloudfront.net/uploads/2017/11/justin-fairfax-1000x667-f63f8ad.jpg 1000w, https://dawm7kda6y2v0.cloudfront.net/uploads/2017/11/justin-fairfax-98x64-b40ef4c.jpg 98w, https://dawm7kda6y2v0.cloudfront.net/uploads/2017/11/justin-fairfax-804x536-2f77c5f@2x.jpg 1608w, https://dawm7kda6y2v0.cloudfront.net/uploads/2017/11/justin-fairfax-600x400-774f3ae@2x.jpg 1200w, https://dawm7kda6y2v0.cloudfront.net/uploads/2017/11/justin-fairfax-1000x667-f63f8ad@2x.jpg 2000w, https://dawm7kda6y2v0.cloudfront.net/uploads/2017/11/justin-fairfax-98x64-b40ef4c@2x.jpg 196w" sizes="(max-width: 804px) 100vw, 804px" /&gt;&lt;figcaption class="wp-caption-text"&gt;&lt;em&gt;Democrat Lt. Gov.-elect Justin Fairfax addresses the Ralph Northam For Governor election night party at George Mason University in Fairfax, Va., Tuesday, Nov. 7, 2017. (AP Photo/Cliff Owen)&lt;/em&gt;&lt;/figcaption&gt;&lt;/figure&gt;
+&lt;p&gt;Democrat Justin Fairfax became the second African-American man to win statewide office in Virginia when he won the lieutenant governor race. Former Gov. Doug Wilder was the first African-American to hold statewide office in Virginia.&lt;/p&gt;
+&lt;h2&gt;Hala Ayala and Elizabeth Guzman&lt;/h2&gt;
+&lt;p&gt;Virginia also &lt;a href="https://www.usatoday.com/story/news/politics/onpolitics/2017/11/07/virginia-elects-second-african-american-statewide-office-first-latinas-state-house/842720001/"&gt;elected&lt;/a&gt; its first two Latina state delegates when Democrats Hala Ayala and Elizabeth Guzman won their elections.&lt;/p&gt;
+&lt;h2&gt;Sheila Oliver&lt;/h2&gt;
+&lt;p&gt;New Jersey voters elected their first female African-American lieutenant governor Tuesday night, Sheila Oliver. The Democrat was also the &lt;a href="http://www.nj.com/politics/index.ssf/2017/07/7_things_to_know_about_sheila_oliver_phil_murphys.html"&gt;first&lt;/a&gt; black woman to serve as the New Jersey state assembly speaker.&lt;/p&gt;
+&lt;p&gt;&amp;#8220;This may not be the first glass ceiling I have broken, but it is certainly the highest,” Oliver said Tuesday night, according to the &lt;a href="https://www.huffingtonpost.com/entry/democratic-victories-firsts-election-day_us_5a026c51e4b092053058cf38"&gt;Huffington Post&lt;/a&gt;. “And I hope somewhere in this great state of New Jersey, a young girl of color is watching tonight and realizing that she does not have a limit to how high she can go.”&lt;/p&gt;
+&lt;h2&gt;Tyler Titus&lt;/h2&gt;
+&lt;p&gt;Pennsylvania &lt;a href="http://www.pennlive.com/news/2017/11/tyler_titus_wins_seat_to_becom.html"&gt;elected&lt;/a&gt; its first openly transgender person to public office when Tyler Titus won a seat on the Erie School Board.&lt;/p&gt;
+&lt;h2&gt;Ravi Bhalla&lt;/h2&gt;
+&lt;p&gt;Hoboken, New Jersey elected its first Sikh mayor Tuesday night, Ravi Bhalla. He is one of the first Sikhs to win a mayoral race in the U.S., following in the footsteps of former Charlottesville Mayor Satyendra Huja.&lt;/p&gt;
+&lt;p&gt;Bhalla faced racist flyers in the last days of the campaign that read, &amp;#8220;Don’t let TERRORISM take over our town.&amp;#8221;&lt;/p&gt;
+&lt;blockquote class="twitter-tweet" data-width="550"&gt;
+&lt;p lang="en" dir="ltr"&gt;Yesterday, a flyer w/ word “terrorist” above a pic of me was circulated in Hob. Of course this is troubling, but we won’t let hate win. &lt;a href="https://t.co/Ri9xrYF4Al"&gt;pic.twitter.com/Ri9xrYF4Al&lt;/a&gt;&lt;/p&gt;
+&lt;p&gt;&amp;mdash; Ravinder S. Bhalla (@RaviBhalla) &lt;a href="https://twitter.com/RaviBhalla/status/926795691720048640?ref_src=twsrc%5Etfw"&gt;November 4, 2017&lt;/a&gt;&lt;/p&gt;&lt;/blockquote&gt;
+&lt;p&gt;&lt;script async src="https://platform.twitter.com/widgets.js" charset="utf-8"&gt;&lt;/script&gt;&lt;/p&gt;
+&lt;h2&gt;Wilmot Collins&lt;/h2&gt;
+&lt;p&gt;Wilmot Collins &lt;a href="https://qz.com/1123804/us-elections-2017-diverse-democratic-candidates-overcame-attacks-to-win-their-hometown-races/"&gt;became&lt;/a&gt; Montana&amp;#8217;s first black mayor when he won the mayoral race in Helena Tuesday night. Collins came to the U.S. in 1994 as a &lt;a href="https://www.pri.org/stories/2016-05-25/what-he-ll-say-new-refugees-montana-i-will-tell-them-you-have-have-thick-skin"&gt;refugee&lt;/a&gt; from Liberia and now works for the state&amp;#8217;s Department of Health and Human Services.&lt;/p&gt;
+&lt;h2&gt;Melvin Carter&lt;/h2&gt;
+&lt;p&gt;St. Paul, Minnesota, &lt;a href="http://www.startribune.com/st-paul-mayoral-race-likely-won-t-be-decided-until-late-this-week/455994913/#1"&gt;elected&lt;/a&gt; its first black mayor Tuesday night, Melvin Carter.&lt;/p&gt;</content>
+    <author>
+      <name>Caitlin MacNeal</name>
+    </author>
+  </entry>
+  <entry>
+    <id>tag:talkingpointsmemo.com,2005:ArticleDecorator/270043</id>
+    <published>2017-11-08T11:46:18-05:00</published>
+    <updated>2017-11-08T11:46:18-05:00</updated>
+    <link rel="alternate" type="text/html" href="/livewire/paul-ryan-republicans-already-chose-trump-democrats-election-day-rout"/>
+    <title>Ryan: GOP Is Sticking 'With Trump' Despite Election Day Rout By Dems</title>
+    <content type="html">&lt;p&gt;House Speaker Paul Ryan (R-WI) on Wednesday said Republicans are sticking with President Donald Trump and his policies, despite a thorough state-level rout Tuesday night as Democrats won coast-to-coast victories.&lt;/p&gt;
+&lt;p&gt;&amp;#8220;Democrats are saying, this is the beginning of our turnaround. What do you take from Ed Gillespie&amp;#8217;s significant loss yesterday?&amp;#8221; Fox News host Brian Kilmeade asked Ryan on his radio show, referring to the Virginia gubernatorial race.&lt;/p&gt;
+&lt;p&gt;&amp;#8220;Obviously, you know, Democrats are going to do that, and we would be saying the same kind of thing,&amp;#8221; Ryan said. &amp;#8220;That&amp;#8217;s the way the spin works on these things.&amp;#8221;&lt;/p&gt;
+&lt;p&gt;Lt. Gov. Ralph Northam (D) swept to a blowout victory in Virginia&amp;#8217;s gubernatorial race over former Republican National Committee Chairman Ed Gillespie.&lt;/p&gt;
+&lt;p&gt;Ryan said the election results show that Republicans need to pass legislation.&lt;/p&gt;
+&lt;p&gt;&amp;#8220;We&amp;#8217;ve got to get our job done,&amp;#8221; he said.&lt;/p&gt;
+&lt;p&gt;Asked whether elected Republican officials are having second thoughts about adopting Trump&amp;#8217;s policies and positions wholesale after their Election Day rout, Ryan said Republicans &amp;#8220;already made that choice.&amp;#8221;&lt;/p&gt;
+&lt;p&gt;&amp;#8220;Is it going to be a choice for Republicans, Bush or Trump?&amp;#8221; Kilmeade asked, referring to former President George W. Bush.&lt;/p&gt;
+&lt;p&gt;&amp;#8220;We already made that choice. We&amp;#8217;re with Trump. We already made that choice. That&amp;#8217;s a choice we made at the beginning of the year. That&amp;#8217;s a choice we made during the campaign,&amp;#8221; Ryan said. &amp;#8220;We ran on a joint agenda with Donald Trump.&amp;#8221;&lt;/p&gt;
+&lt;p&gt;Voters rejected that agenda on Tuesday, and Democratic candidates &lt;a href="http://talkingpointsmemo.com/dc/democrats-smell-blood-in-the-water-for-2018-after-tuesdays-electoral-romp"&gt;swept statewide offices&lt;/a&gt;, beating Republican candidates who adopted Trump&amp;#8217;s rhetoric and policies as their own.&lt;/p&gt;</content>
+    <author>
+      <name>Esme Cribb</name>
+    </author>
+  </entry>
+  <entry>
+    <id>tag:talkingpointsmemo.com,2005:ArticleDecorator/270042</id>
+    <published>2017-11-08T11:25:12-05:00</published>
+    <updated>2017-11-08T11:25:12-05:00</updated>
+    <link rel="alternate" type="text/html" href="/news/trump-admin-strict-rules-americans-visiting-cuba"/>
+    <title>Trump Admin Releases Lengthy List Of Strict Rules For Americans Visiting Cuba</title>
+    <content type="html">&lt;p&gt;WASHINGTON (AP) — Americans who visit Cuba must now avoid hotels, shops, tour companies and other businesses on a lengthy list released Wednesday by the Trump administration as part of a new policy aimed at cracking down on the communist-run island&amp;#8217;s government.&lt;/p&gt;
+&lt;p&gt;U.S. travelers will once again be required to go as part of organized tour groups run by U.S. companies, and a representative of the sponsoring group must accompany the travelers. That&amp;#8217;s a return to the stricter rules that existed before former President Barack Obama and Cuban President Raul Castro restored diplomatic relations in 2015.&lt;/p&gt;
+&lt;p&gt;The new rules and list of off-limits entities are intended to put in place the tougher Cuba policy that President Donald Trump announced in June. Trump&amp;#8217;s administration took several months to finalize the details of that policy, which will take affect Thursday.&lt;/p&gt;
+&lt;p&gt;Some exceptions will accommodate Americans who made plans or entered into business agreements before Trump&amp;#8217;s policy announcement June 16, such as &amp;#8220;people to people&amp;#8221; trips to Cuba.&lt;/p&gt;
+&lt;p&gt;But at the same time, the Treasury Department said it is expanding and simplifying a license that allows some products to be exported to Cuba without specific permission from the U.S. government. The goal in allowing those exports is to enable Americans to help the growing private sector in Cuba, including small businesses that have popped up across the island in recent years.&lt;/p&gt;
+&lt;p&gt;&amp;#8220;We have strengthened our Cuba policies to channel economic activity away from the Cuban military and to encourage the government to move toward greater political and economic freedom for the Cuban people,&amp;#8221; Treasury Secretary Steven Mnuchin said.&lt;/p&gt;
+&lt;p&gt;The list of off-limits entities bars American business with the large military-run corporations that dominate the Cuban economy. These include GAESA and CIMEX, the holding companies that control most retail business on the island; Gaviota, the largest tourism company; and Habaguanex, the firm that runs Old Havana.&lt;/p&gt;
+&lt;p&gt;It also places off limits a new cargo port and special trade zone outside the city of Mariel that has been the focus of Cuba&amp;#8217;s efforts to draw foreign investment in manufacturing and distribution.&lt;/p&gt;
+&lt;p&gt;A list of blacklisted military-run hotels includes the Manzana Kempinski, which opened with great fanfare this year as Cuba&amp;#8217;s first hotel to meet the international five-star standard.&lt;/p&gt;
+&lt;p&gt;The actual impact on American business with Cuba will likely be limited because that trade is already sparse, and the rules allow it to largely continue. Many American travelers stay at hotels not on the new list, and the company that imports most American food products to Cuba is similarly unaffected. U.S. flight and cruises are exempted as well.&lt;/p&gt;
+&lt;p&gt;Left unchanged is a U.S. travel warning that urges all Americans to stay away from Cuba. The administration issued that warning in September amid a series of invisible, unexplained attacks that have harmed the health of U.S. government personnel in Havana. The U.S. says 24 Americans are &amp;#8220;medically confirmed&amp;#8221; to have been affected by those attacks.&lt;/p&gt;</content>
+    <author>
+      <name>JOSH LEDERMAN</name>
+    </author>
+  </entry>
+  <entry>
+    <id>tag:talkingpointsmemo.com,2005:ArticleDecorator/270041</id>
+    <published>2017-11-08T11:13:26-05:00</published>
+    <updated>2017-11-08T11:13:26-05:00</updated>
+    <link rel="alternate" type="text/html" href="/livewire/dave-brat-virginia-republicans-nationalize-election"/>
+    <title>GOP Rep. Dave Brat: Virginia GOP Didn't 'Nationalize' Election Enough</title>
+    <content type="html">&lt;p class="p1"&gt;Rep. Dave Brat (R-VA) said Wednesday that Republicans up and down the ticket in his home state had failed to “nationalize” the election — but he insisted Republicans’ stunning losses across Virginia weren’t a referendum on President Donald Trump.&lt;/p&gt;
+&lt;p class="p1"&gt;“I always deal in policy, not personality and all the drama,” Brat told CNN’s John Berman and Poppy Harlow. “I don’t think it’s ever a matter of personality.”&lt;/p&gt;
+&lt;p class="p1"&gt;Instead, while avoiding mentioning Trump by name, he said Republicans ought to have focused their local races on national issues: Namely, Republicans’ (failed) efforts to repeal Obamacare and the proposed massive tax cut bill — currently making its way through the House Ways and Means Committee — that would slash corporate taxes and eliminate the estate tax, among many other things.&lt;/p&gt;
+&lt;p class="p1"&gt;“I think we were running too much on state issues,” Brat said. &lt;span class="s1"&gt;“&lt;/span&gt;&lt;span class="s2"&gt;Even at the state level, Virginia only grew at 0.6 percent GDP growth rate last year. That&amp;#8217;s not good. And yet two-thirds of people came out to the polls saying ‘the economy is doing fine.’ So we failed to message on the economy.&amp;#8221;&lt;/span&gt;&lt;/p&gt;
+&lt;p class="p3"&gt;&lt;span class="s2"&gt;He added: “Obamacare premiums are going out with 40 percent increases across the state. The Democrats are running on health care, but they&amp;#8217;re not running on Obamacare failure.” &lt;/span&gt;&lt;/p&gt;
+&lt;p class="p3"&gt;&lt;span class="s2"&gt;“And so we failed to message at the proper level, on the national level.” &lt;/span&gt;&lt;/p&gt;
+&lt;p class="p3"&gt;&lt;span class="s2"&gt;It was a striking message: highlighting slow economic growth and rising health care costs are normally reserved for opposition parties. But in the White House and Congress, and at the state level in Virginia’s legislature, Republicans exercise blanket majorities. The state’s governor, Terry McAuliffe, is a Democrat. Brat wanted local Republicans to run on national Republicans&amp;#8217; stalled agenda, but not on the President himself.&lt;/span&gt;&lt;/p&gt;
+&lt;p class="p3"&gt;&lt;span class="s2"&gt;President Donald Trump, tweeting on Tuesday, hadn&amp;#8217;t yet had a chance to hear Brat&amp;#8217;s advice.&lt;/span&gt;&lt;/p&gt;
+&lt;blockquote class="twitter-tweet" data-width="550"&gt;
+&lt;p lang="en" dir="ltr"&gt;Ed Gillespie worked hard but did not embrace me or what I stand for. Don’t forget, Republicans won 4 out of 4 House seats, and with the economy doing record numbers, we will continue to win, even bigger than before!&lt;/p&gt;
+&lt;p&gt;&amp;mdash; Donald J. Trump (@realDonaldTrump) &lt;a href="https://twitter.com/realDonaldTrump/status/928074747316928513?ref_src=twsrc%5Etfw"&gt;November 8, 2017&lt;/a&gt;&lt;/p&gt;&lt;/blockquote&gt;
+&lt;p&gt;&lt;script async src="https://platform.twitter.com/widgets.js" charset="utf-8"&gt;&lt;/script&gt;&lt;/p&gt;
+&lt;p class="p3"&gt;&lt;span class="s2"&gt;Brat acknowledged during the interview that the Senate had done a “face plant” by failing to repeal Obamacare, but expressed confusion when asked if the President negatively affected Republicans’ chances. &lt;/span&gt;&lt;/p&gt;
+&lt;p class="p6"&gt;&lt;span class="s2"&gt;“If you look at the exit poll numbers, twice as many people in Virginia came out to vote in part because of opposition to this President than in support of this President,” Harlow pressed.&lt;/span&gt;&lt;/p&gt;
+&lt;p class="p6"&gt;&lt;span class="s2"&gt;“So yes or no, say it like it is, referendum on this President or no?” &lt;/span&gt;&lt;/p&gt;
+&lt;p class="p6"&gt;&lt;span class="s2"&gt;“It depends on what you mean on by — on the agenda, no,” Brat began to reply.&lt;/span&gt;&lt;/p&gt;
+&lt;p class="p6"&gt;&lt;span class="s2"&gt;“On the man,” Harlow said.&lt;/span&gt;&lt;/p&gt;
+&lt;p class="p6"&gt;&lt;span class="s2"&gt;“I don&amp;#8217;t think it&amp;#8217;s ever a matter of personality. Last night, the evidence was health care and the economy growth. Economy in Virginia is failing right now and government jobs are tied to that economy. &lt;/span&gt;&lt;span class="s4"&gt;And so it&amp;#8217;s staggering that northern Virginia can go along with such low economic growth.&amp;#8221;&lt;/span&gt;&lt;/p&gt;</content>
+    <author>
+      <name>Matt Shuham</name>
+    </author>
+  </entry>
+</feed>

--- a/test/xmlbase.js
+++ b/test/xmlbase.js
@@ -67,6 +67,29 @@ describe('xmlbase', function(){
     });
   });
 
+  it('should resolve relative URI item links with an empty xml:base', function (done) {
+    var feed = __dirname + '/feeds/tpm-with-empty-base.atom';
+    var links = [];
+
+    fs.createReadStream(feed).pipe(new FeedParser())
+    .on('readable', function () {
+      var item;
+      while ((item = this.read())) {
+        links.push(item.link);
+      }
+    })
+    .on('error', function (err) {
+      assert.ifError(err);
+      done(err);
+    })
+    .on('end', function () {
+      assert.equal(links[0], '/livewire/hannity-announces-fox-hired-sebastian-gorka-national-security-strategist');
+      assert.equal(links[1], '/edblog/were-hiring-senior-editor');
+      assert.equal(links.length, 20);
+      done();
+    });
+  });
+
   it('should resolve relative URI item links in RSS with feedurl option', function (done) {
     var feed = __dirname + '/feeds/rss-with-relative-urls.xml';
     var links = [];


### PR DESCRIPTION
I noticed that a feed with an empty `xml:base=""` breaks the parsing algorithm in a strange way. I came across such a feed in the wild. This PR attempts to fix that. Please let me know if anything needs to be changed.

I added a new test fixture which is a copy of `test/feeds/tpm.atom`. The only difference is that I added `xml:base=""`.

The test that I added breaks with the new fixture. The additional checks fix the problem. I'm not sure though if it's the best way to do this as I'm not familiar with the code base. Please let me know if it should be done differently.